### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "lusitanian/oauth",
+    "description": "PHP 5.4+ oAuth 2 Library",
+    "keywords": ["oauth"],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "David Desberg",
+            "email": "alusitanian@gmail.com"
+        },
+        {
+            "name": "Pieter Hordijk",
+            "email": "info@pieterhordijk.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.4.0"
+    },
+    "suggest": {
+        "rdlowrey/artax": "Implementation of OAuth\\Common\\Http\\ClientInterface"
+    },
+    "autoload": {
+        "psr-0": { "OAuth": "src" }
+    }
+}


### PR DESCRIPTION
I put the name under the vendor `lusitianian`, but you are free to change it. I did not want to claim `oauth` as a vendor name, since that would imply the library being "official".

Next steps:
- Sign up on [packagist.org](https://packagist.org/) and submit the package
- Set up the GitHub post-receive hook for packagist ([here](https://github.com/Lusitanian/PHPoAuthLib/settings/hooks))
- Optional: Add @PeeHaa as a manitainer on packagist
- Optional: Add instructions for composer-based installation to README

Ping me if you have any questions.
