### PR TITLE
Fix Facebook base-api-uri

### DIFF
--- a/examples/facebook.php
+++ b/examples/facebook.php
@@ -39,7 +39,7 @@ if( !empty( $_GET['code'] ) ) {
     $token = $facebookService->requestAccessToken( $_GET['code'] );
 
     // Send a request with it
-    $result = json_decode( $facebookService->request( 'https://graph.facebook.com/me' ), true );
+    $result = json_decode( $facebookService->request( '/me' ), true );
 
     // Show some of the resultant data
     echo 'Your unique facebook user id is: ' . $result['id'] . ' and your name is ' . $result['name'];

--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -15,7 +15,7 @@ class Facebook extends AbstractService
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
         if( null === $baseApiUri ) {
-            $this->baseApiUri = new Uri('https://graph.facebook.com/oauth/');
+            $this->baseApiUri = new Uri('https://graph.facebook.com/');
         }
     }
 


### PR DESCRIPTION
This fixes the base-api-url for the Facebook-service and changes the example accordingly.
