### PR TITLE
Added Refresh Token support Facebook

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -56,6 +56,11 @@ class Facebook extends AbstractService
         $token->setAccessToken( $data['access_token'] );
         $token->setLifeTime( $data['expires'] );
 
+        if( isset($data['refresh_token'] ) ) {
+            $token->setRefreshToken( $data['refresh_token'] );
+            unset($data['refresh_token']);
+        }
+
         unset( $data['access_token'] );
         unset( $data['expires'] );
         $token->setExtraParams( $data );


### PR DESCRIPTION
Facebook uses refresh tokens (as you can tell form its use of the `expires` data, and now that offline_access is being removed its even more important to support this.
