### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -20,7 +20,7 @@ class Session implements TokenStorageInterface
      */
     public function __construct($startSession = true, $sessionVariableName = 'lusitanian_oauth_token')
     {
-        if( $startSession && session_status() === PHP_SESSION_NONE) {
+        if( $startSession && !isset($_SESSION)) {
             session_start();
         }
 


### PR DESCRIPTION
Unfortunately, session_status() is a method introduced in PHP 5.4.
For 5.3 compatibility, the best we can do is just to check whether 
the session exists.
