### PR TITLE
authorize → authenticate

### DIFF
--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -24,7 +24,7 @@ class Foursquare extends AbstractService
      */
     public function getAuthorizationEndpoint()
     {
-        return new Uri('https://foursquare.com/oauth2/authorize');
+        return new Uri('https://foursquare.com/oauth2/authenticate');
     }
 
     /**


### PR DESCRIPTION
The Foursquare api [documentation](https://developer.foursquare.com/overview/auth) states:

The examples above use /authenticate instead of /authorize, which what the OAuth protocol specifies. Following precedent established by Twitter and LinkedIn, /authenticate handles both user authentication and app authorization and automatically redirects if a user has already authorized the calling app. Conversely, /authorize will prompt the user to accept the the auth request every time.

That's why maybe, `/authenticate` is preferred.
