### PR TITLE
Adding support for JSON strings into the request body.

### DIFF
--- a/src/OAuth/Common/Http/Client/StreamClient.php
+++ b/src/OAuth/Common/Http/Client/StreamClient.php
@@ -60,7 +60,9 @@ class StreamClient implements ClientInterface
         $extraHeaders['Host'] = 'Host: '.$endpoint->getHost();
         $extraHeaders['Connection'] = 'Connection: close';
 
-        if( is_array($requestBody) ) {
+        if ( isset($extraHeaders['Content-type']) and $extraHeaders['Content-type'] == 'Content-type: application/json') {
+            $requestBody = json_encode($requestBody);
+        }else if( is_array($requestBody) ) {
             $requestBody = http_build_query($requestBody);
         }
 


### PR DESCRIPTION
Hello there, 

I was trying to send data to LinkedIn API with a POST request, but came accross a particular problem. Whenever I was sending data to the API, the Stream Client was changing it into a http querry.. which of course made my request fail..

So i added support for JSON by adding a Content-type header with the value of application/json. 

To me it makes sens that if that is the header of the request, we expect a valid JSON string to be passed and not an http querry.

Let me know what you guys think.
