### PR TITLE
Added stored token secret as default value in OAuth1.0 access token requests

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -87,8 +87,12 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * @return TokenInterface $token
      * @throws TokenResponseException
      */
-    public function requestAccessToken($token, $verifier, $tokenSecret)
+    public function requestAccessToken($token, $verifier, $tokenSecret = null)
     {
+        if($tokenSecret === null) {
+            $storedRequestToken = $this->storage->retrieveAccessToken($this->service());
+            $tokenSecret = $storedRequestToken->getRequestTokenSecret();
+        }
         $this->signature->setTokenSecret($tokenSecret);
 
         $extraAuthenticationHeaders = array(


### PR DESCRIPTION
As in both OAuth1.0 examples (i.e. Twitter and Fitbit) the request token secret is extracted manually from the storage, I thought it could be used as a default value of `requestAccessToken(...)`.
This way the `TokenStorageInterface` has only to be handed over to the `ServiceFactory` and no manual interaction with the storage is needed.

If needed, I will change the examples accordingly.
