### PR TITLE
Fix composer.json:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
+        "symfony/http-foundation": "~2.1",
+        "predis/predis": "0.8.*@dev",
         "phpunit/phpunit": "3.7.*"
     },
     "suggest": {


### PR DESCRIPTION
A couple of small fixes to composer.json.
Symfony's http-foundation and predis are not strict requirements, nor are they development-only; they are optional components, so I moved the to the `suggest` section of composer.
At the same time, PHPUnit is required to run tests, which is what composer's `require-dev` section is for: development packages; so I added it there.
The psr-0 section is also changed because I didn't notice it - I have Sublime Text 2 condigured for automatically stripping out trailing white space, which it did on those lines.
- Make symfony/http-foundation and predis/predis suggestions instead of -dev requirements.
- Add PHPUnit to require-dev.
