### PR TITLE
Do not overwrite OAuth session if already present.

### DIFF
--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -25,7 +25,10 @@ class Session implements TokenStorageInterface
         }
 
         $this->sessionVariableName = $sessionVariableName;
-        $_SESSION[$sessionVariableName] = array();
+        if (!isset($_SESSION[$sessionVariableName]))
+        {
+            $_SESSION[$sessionVariableName] = array();
+        }
     }
 
     /**

--- a/src/OAuth/Common/Storage/SymfonySession.php
+++ b/src/OAuth/Common/Storage/SymfonySession.php
@@ -15,7 +15,10 @@ class SymfonySession implements TokenStorageInterface
         $this->session = $session;
         $this->sessionVariableName = $sessionVariableName;
 
-        $this->session->set($sessionVariableName, array());
+        if (!$this->session->has($sessionVariableName))
+        {
+            $this->session->set($sessionVariableName, array());
+        }
     }
 
     /**


### PR DESCRIPTION
`Session` and `SymfonySession` should not set `lusitanian_oauth_token` on instantiation if it already exists in the session. Doing so causes the OAuth to fail with: `TokenNotFoundException('Token not found in session, are you sure you stored it?');`
