### PR TITLE
Add tests for session storage constructors

### DIFF
--- a/tests/OAuth/Unit/Common/Storage/SessionTest.php
+++ b/tests/OAuth/Unit/Common/Storage/SessionTest.php
@@ -9,11 +9,11 @@
 
 use OAuth\Common\Storage\Session;
 use OAuth\Unit\Common\Storage\StorageTest;
+use OAuth\OAuth2\Token\StdOAuth2Token;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class SessionTest extends StorageTest
 {
-
     public function setUp()
     {
         // set it
@@ -26,4 +26,22 @@ class SessionTest extends StorageTest
         // empty
     }
 
+    /**
+     * Check that the token survives the constructor
+     */
+    public function testStorageSurvivesConstructor()
+    {
+        $service = 'Facebook';
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service, $token);
+        $this->storage = null;
+        $this->storage = new Session(false);
+
+        // assert
+        $extraParams = $this->storage->retrieveAccessToken($service)->getExtraParams();
+        $this->assertEquals('param', $extraParams['extra']);
+        $this->assertEquals($token, $this->storage->retrieveAccessToken($service));
+    }
 }

--- a/tests/OAuth/Unit/Common/Storage/SymfonySessionTest.php
+++ b/tests/OAuth/Unit/Common/Storage/SymfonySessionTest.php
@@ -9,17 +9,19 @@
 
 use OAuth\Common\Storage\SymfonySession;
 use OAuth\Unit\Common\Storage\StorageTest;
+use OAuth\OAuth2\Token\StdOAuth2Token;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 
 class SymfonySessionTest extends StorageTest
 {
+    protected $session;
 
     public function setUp()
     {
         // set it
-        $session = new Session(new MockArraySessionStorage());
-        $this->storage = new SymfonySession($session);
+        $this->session = new Session(new MockArraySessionStorage());
+        $this->storage = new SymfonySession($this->session);
     }
 
     public function tearDown()
@@ -29,4 +31,22 @@ class SymfonySessionTest extends StorageTest
         unset($this->storage);
     }
 
+    /**
+     * Check that the token survives the constructor
+     */
+    public function testStorageSurvivesConstructor()
+    {
+        $service = 'Facebook';
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service, $token);
+        $this->storage = null;
+        $this->storage = new SymfonySession($this->session);
+
+        // assert
+        $extraParams = $this->storage->retrieveAccessToken($service)->getExtraParams();
+        $this->assertEquals('param', $extraParams['extra']);
+        $this->assertEquals($token, $this->storage->retrieveAccessToken($service));
+    }
 }


### PR DESCRIPTION
This adds tests for `SessionStorage` and `SymfonySessionStorage` for the issue fixed in #81 (the constructor clobbers the session array).
