### PR TITLE
Bug fix - First argument should be service name

### DIFF
--- a/src/OAuth/OAuth2/Service/Bitly.php
+++ b/src/OAuth/OAuth2/Service/Bitly.php
@@ -87,7 +87,7 @@ class Bitly extends AbstractService
         parse_str($responseBody, $parsedResult);
 
         $token = $this->parseAccessTokenResponse( json_encode($parsedResult) );
-        $this->storage->storeAccessToken( $token );
+        $this->storage->storeAccessToken( $this->service(), $token );
 
         return $token;
     }


### PR DESCRIPTION
As defined in the TokenStorageInterface src/OAuth/Common/Storage

Fixes #85
