### PR TITLE
Readme update - Tumblr is OAuth 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Included service implementations
 --------------------------------
 - OAuth1
     - Twitter
+    - Tumblr
     - FitBit
 - OAuth2
     - Google
@@ -57,7 +58,6 @@ Included service implementations
     - Instagram
     - LinkedIn
     - Box
-    - Tumblr
     - Vkontakte
 - more to come!
 


### PR DESCRIPTION
Tumblr is OAuth 1.0 https://github.com/Lusitanian/PHPoAuthLib/tree/master/src/OAuth/OAuth1/Service

Not found on the OAuth2 dir https://github.com/Lusitanian/PHPoAuthLib/tree/master/src/OAuth/OAuth2/Service
