### PR TITLE
Fixed deprecation warnings from foursquare

### DIFF
--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -11,6 +11,8 @@ use OAuth\Common\Http\Uri\UriInterface;
 
 class Foursquare extends AbstractService
 {
+	private $apiVersionDate = '20130829';
+
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
@@ -61,4 +63,12 @@ class Foursquare extends AbstractService
 
         return $token;
     }
+
+    public function request($path, $method = 'GET', array $body = array(), array $extraHeaders = array()){
+    	$uri = new Uri($this->baseApiUri . $path);
+    	$uri->addToQuery('v', $this->apiVersionDate);
+
+    	return parent::request($uri, $method = 'GET', $body, $extraHeaders);
+    }
+
 }


### PR DESCRIPTION
Foursquare requires you to pass a query variable `v=YYYYMMDD` that specifies the last date that your api implementation was checked against.

When making a call to to the API using the `AbstractService` `request` method I get the following warning

``` php
stdClass Object
(
    [meta] => stdClass Object
        (
            [code] => 200
            [errorType] => deprecated
            [errorDetail] => Please provide an API version to avoid future errors.See http://bit.ly/vywCav
        )
)
```

Taking a look at http://bit.ly/vywCav says that we should be passing a a `v` query string parameter in the format of YYYYMMDD that specifies that last date that we checked out implementation of the API was up to date. If they have made a breaking change since that date we get several months in order to update our implementation.

I've added `$apiVersionDate` and passed that along with requests to the API path using `addToQuery` from `OAuth\Common\Http\Uri\Uri`

This removes the deprecation warnings from foursquare. And will allow us to check for any upcoming breaking changes in the future by looking out for the deprecated response foursquare returns.
