### PR TITLE
Fixes #92 check if array before using array_merge

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -193,10 +193,10 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * @param string $method
      * @param UriInterface $uri the uri the request is headed
      * @param \OAuth\OAuth1\Token\TokenInterface $token
-     * @param $bodyParams array
+     * @param $bodyParams Request body if applicable (key/value pairs)
      * @return string
      */
-    protected function buildAuthorizationHeaderForAPIRequest($method, UriInterface $uri, TokenInterface $token, $bodyParams)
+    protected function buildAuthorizationHeaderForAPIRequest($method, UriInterface $uri, TokenInterface $token, $bodyParams = null)
     {
         $this->signature->setTokenSecret($token->getAccessTokenSecret());
         $parameters = $this->getBasicAuthorizationHeaderInfo();
@@ -205,7 +205,10 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         }
 
         $parameters = array_merge($parameters, array('oauth_token' => $token->getAccessToken()) );
-        $parameters['oauth_signature'] = $this->signature->getSignature($uri, array_merge($parameters, $bodyParams), $method);
+
+        $mergedParams = (is_array($bodyParams)) ? array_merge($parameters, $bodyParams) : $parameters;
+
+        $parameters['oauth_signature'] = $this->signature->getSignature($uri, $mergedParams, $method);
 
         $authorizationHeader = 'OAuth ';
         $delimiter = '';


### PR DESCRIPTION
Also updated the doc bloc to the $bodyParams param, and set a default value of null to better represent what may get passed in.

This fixes my issue. However I'm not sure on one thing... will $bodyParams always be an array or null these days? Should we be doing something else here to merge these two variables if $bodyParam is no longer always an array.
