### PR TITLE
Bug fix incompatible declaration of request method

### DIFF
--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -64,7 +64,7 @@ class Foursquare extends AbstractService
         return $token;
     }
 
-    public function request($path, $method = 'GET', array $body = array(), array $extraHeaders = array()){
+    public function request($path, $method = 'GET', $body = null, array $extraHeaders = array()){
     	$uri = new Uri($this->baseApiUri . $path);
     	$uri->addToQuery('v', $this->apiVersionDate);
 


### PR DESCRIPTION
`$body` is now null, not an array.
This definition caused an error.

Declaration of OAuth\OAuth2\Service\Foursquare::request() must be compatible with that of OAuth\Common\Service\ServiceInterface::request()
