### PR TITLE
PSR-2 compliance and PHPDoc formatting (manual pass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Included service implementations
     - Twitter
     - Tumblr
     - FitBit
+    - Etsy
 - OAuth2
     - Google
     - Microsoft

--- a/examples/amazon.php
+++ b/examples/amazon.php
@@ -1,13 +1,15 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Amazon service
  *
  * PHP version 5.4
  *
- * @author Flávio Heleno <flaviohbatista@gmail.com>
+ * @author     Flávio Heleno <flaviohbatista@gmail.com>
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Amazon;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -31,17 +33,17 @@ $credentials = new Credentials(
 /** @var $amazonService Amazon */
 $amazonService = $serviceFactory->createService('amazon', $credentials, $storage, array('profile'));
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from Amazon, get the token
-    $token = $amazonService->requestAccessToken( $_GET['code'] );
+    $token = $amazonService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $amazonService->request( '/user/profile' ), true );
+    $result = json_decode($amazonService->request('/user/profile'), true);
 
     // Show some of the resultant data
     echo 'Your unique Amazon user id is: ' . $result['user_id'] . ' and your name is ' . $result['name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $amazonService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/bitly.php
+++ b/examples/bitly.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Bitly service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Bitly;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -32,17 +34,17 @@ $credentials = new Credentials(
 /** @var $bitlyService Bitly */
 $bitlyService = $serviceFactory->createService('bitly', $credentials, $storage);
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from bitly, get the token
-    $bitlyService->requestAccessToken( $_GET['code'] );
+    $bitlyService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $bitlyService->request('user/info'), true );
+    $result = json_decode($bitlyService->request('user/info'), true);
 
     // Show some of the resultant data
     echo 'Your unique user id is: ' . $result['data']['login'] . ' and your name is ' . $result['data']['display_name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $bitlyService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Bootstrap the library
  */

--- a/examples/box.php
+++ b/examples/box.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Box service
  *
@@ -10,6 +11,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Box;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -33,17 +35,17 @@ $credentials = new Credentials(
 /** @var $boxService Box */
 $boxService = $serviceFactory->createService('box', $credentials, $storage);
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from box, get the token
-    $token = $boxService->requestAccessToken( $_GET['code'] );
+    $token = $boxService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $boxService->request( '/users/me' ), true );
+    $result = json_decode($boxService->request('/users/me'), true);
 
     // Show some of the resultant data
     echo 'Your Box name is ' . $result['name'] . ' and your email is ' . $result['login'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $boxService->getAuthorizationUri(array('state' => 'blabla'));
     // var_dump($url);
     header('Location: ' . $url);

--- a/examples/dropbox.php
+++ b/examples/dropbox.php
@@ -1,13 +1,15 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Dropbox service
  *
  * PHP version 5.4
  *
- * @author Flávio Heleno <flaviohbatista@gmail.com>
+ * @author     Flávio Heleno <flaviohbatista@gmail.com>
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Dropbox;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -31,17 +33,17 @@ $credentials = new Credentials(
 /** @var $dropboxService Dropbox */
 $dropboxService = $serviceFactory->createService('dropbox', $credentials, $storage, array());
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from Dropbox, get the token
-    $token = $dropboxService->requestAccessToken( $_GET['code'] );
+    $token = $dropboxService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $dropboxService->request( '/account/info' ), true );
+    $result = json_decode($dropboxService->request('/account/info'), true);
 
     // Show some of the resultant data
     echo 'Your unique Dropbox user id is: ' . $result['uid'] . ' and your name is ' . $result['display_name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $dropboxService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/etsy.php
+++ b/examples/etsy.php
@@ -9,6 +9,8 @@
  * @copyright  Copyright (c) 2013 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
+use OAuth\OAuth1\Service\Etsy;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
 
@@ -31,20 +33,22 @@ $credentials = new Credentials(
 /** @var $etsyService Etsy */
 $etsyService = $serviceFactory->createService('Etsy', $credentials, $storage);
 
-if ( !empty( $_GET['oauth_token'] ) ) {
+if (!empty($_GET['oauth_token'])) {
     $token = $storage->retrieveAccessToken('Etsy');
+
     // This was a callback request from Etsy, get the token
     $etsyService->requestAccessToken(
         $_GET['oauth_token'],
         $_GET['oauth_verifier'],
-        $token->getRequestTokenSecret() );
+        $token->getRequestTokenSecret()
+    );
 
     // Send a request now that we have access token
-    $result = json_decode( $etsyService->request( '/private/users/__SELF__') );
+    $result = json_decode($etsyService->request('/private/users/__SELF__'));
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $response = $etsyService->requestRequestToken();
     $extra = $response->getExtraParams();
     $url = $extra['login_url'];

--- a/examples/facebook.php
+++ b/examples/facebook.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Facebook service
  *
@@ -10,6 +11,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Facebook;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -33,17 +35,17 @@ $credentials = new Credentials(
 /** @var $facebookService Facebook */
 $facebookService = $serviceFactory->createService('facebook', $credentials, $storage, array());
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from facebook, get the token
-    $token = $facebookService->requestAccessToken( $_GET['code'] );
+    $token = $facebookService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $facebookService->request( '/me' ), true );
+    $result = json_decode($facebookService->request('/me'), true);
 
     // Show some of the resultant data
     echo 'Your unique facebook user id is: ' . $result['id'] . ' and your name is ' . $result['name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $facebookService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/fitbit.php
+++ b/examples/fitbit.php
@@ -10,6 +10,8 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
+use OAuth\OAuth1\Service\FitBit;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
 
@@ -32,24 +34,26 @@ $credentials = new Credentials(
 /** @var $fitbitService FitBit */
 $fitbitService = $serviceFactory->createService('FitBit', $credentials, $storage);
 
-if ( !empty( $_GET['oauth_token'] ) ) {
+if (!empty($_GET['oauth_token'])) {
     $token = $storage->retrieveAccessToken('FitBit');
+
     // This was a callback request from fitbit, get the token
     $fitbitService->requestAccessToken(
         $_GET['oauth_token'],
         $_GET['oauth_verifier'],
-        $token->getRequestTokenSecret() );
+        $token->getRequestTokenSecret()
+    );
 
     // Send a request now that we have access token
-    $result = json_decode( $fitbitService->request( 'user/-/profile.json') );
+    $result = json_decode($fitbitService->request('user/-/profile.json'));
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     // extra request needed for oauth1 to request a request token :-)
     $token = $fitbitService->requestRequestToken();
 
-    $url = $fitbitService->getAuthorizationUri(['oauth_token' => $token->getRequestToken()]);
+    $url = $fitbitService->getAuthorizationUri(array('oauth_token' => $token->getRequestToken()));
     header('Location: ' . $url);
 } else {
     $url = $currentUri->getRelativeUri() . '?go=go';

--- a/examples/foursquare.php
+++ b/examples/foursquare.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Foursquare service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Foursquare;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -31,17 +33,18 @@ $credentials = new Credentials(
 // Instantiate the Foursquare service using the credentials, http client and storage mechanism for the token
 /** @var $foursquareService Foursquare */
 $foursquareService = $serviceFactory->createService('foursquare', $credentials, $storage);
-if ( !empty( $_GET['code'] ) ) {
-    // This was a callback request from google, get the token
-    $foursquareService->requestAccessToken( $_GET['code'] );
+
+if (!empty($_GET['code'])) {
+    // This was a callback request from foursquare, get the token
+    $foursquareService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $foursquareService->request( 'users/self' ), true );
+    $result = json_decode($foursquareService->request('users/self'), true);
 
     // Show some of the resultant data
     echo 'Your unique foursquare user id is: ' . $result['response']['user']['id'] . ' and your name is ' . $result['response']['user']['firstName'] . $result['response']['user']['lastName'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $foursquareService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/github.php
+++ b/examples/github.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Github service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\GitHub;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -32,13 +34,15 @@ $credentials = new Credentials(
 /** @var $gitHub GitHub */
 $gitHub = $serviceFactory->createService('GitHub', $credentials, $storage, array('user'));
 
-if ( !empty( $_GET['code'] ) ) {
-    // This was a callback request from google, get the token
-    $gitHub->requestAccessToken( $_GET['code'] );
-    $result = json_decode( $gitHub->request( 'user/emails' ), true );
+if (!empty($_GET['code'])) {
+    // This was a callback request from github, get the token
+    $gitHub->requestAccessToken($_GET['code']);
+
+    $result = json_decode($gitHub->request('user/emails'), true);
+
     echo 'The first email on your github account is ' . $result[0];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $gitHub->getAuthorizationUri();
     header('Location: ' . $url);
 

--- a/examples/google.php
+++ b/examples/google.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Google service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Google;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -32,17 +34,17 @@ $credentials = new Credentials(
 /** @var $googleService Google */
 $googleService = $serviceFactory->createService('google', $credentials, $storage, array('userinfo_email', 'userinfo_profile'));
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from google, get the token
-    $googleService->requestAccessToken( $_GET['code'] );
+    $googleService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $googleService->request( 'https://www.googleapis.com/oauth2/v1/userinfo' ), true );
+    $result = json_decode($googleService->request('https://www.googleapis.com/oauth2/v1/userinfo'), true);
 
     // Show some of the resultant data
     echo 'Your unique google user id is: ' . $result['id'] . ' and your name is ' . $result['name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $googleService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/init.example.php
+++ b/examples/init.example.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file sets up the information needed to test the examples in different environments.
  *

--- a/examples/instagram.php
+++ b/examples/instagram.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Instagram service
  *
@@ -10,6 +11,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Instagram;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -35,17 +37,17 @@ $scopes = array('basic', 'comments', 'relationships', 'likes');
 /** @var $instagramService Instagram */
 $instagramService = $serviceFactory->createService('instagram', $credentials, $storage, $scopes);
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from Instagram, get the token
-    $instagramService->requestAccessToken( $_GET['code'] );
+    $instagramService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $instagramService->request( 'users/self' ), true );
+    $result = json_decode($instagramService->request('users/self'), true);
 
     // Show some of the resultant data
     echo 'Your unique instagram user id is: ' . $result['data']['id'] . ' and your name is ' . $result['data']['full_name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $instagramService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/linkedin.php
+++ b/examples/linkedin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Linkedin service
  *
@@ -10,6 +11,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Linkedin;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -33,17 +35,17 @@ $credentials = new Credentials(
 /** @var $linkedinService Linkedin */
 $linkedinService = $serviceFactory->createService('linkedin', $credentials, $storage, array('r_basicprofile'));
 
-if ( !empty( $_GET['code'] ) ) {
-    // This was a callback request from google, get the token
-    $token = $linkedinService->requestAccessToken( $_GET['code'] );
+if (!empty($_GET['code'])) {
+    // This was a callback request from linkedin, get the token
+    $token = $linkedinService->requestAccessToken($_GET['code']);
 
     // Send a request with it. Please note that XML is the default format.
-    $result = json_decode( $linkedinService->request( '/people/~?format=json' ), true );
+    $result = json_decode($linkedinService->request('/people/~?format=json'), true);
 
     // Show some of the resultant data
     echo 'Your linkedin first name is ' . $result['firstName'] . ' and your last name is ' . $result['lastName'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     // state is used to prevent CSRF, it's required
     $url = $linkedinService->getAuthorizationUri(array('state' => 'DCEEFWF45453sdffef424'));
     header('Location: ' . $url);

--- a/examples/microsoft.php
+++ b/examples/microsoft.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Microsoft service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Microsoft;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -32,13 +34,13 @@ $credentials = new Credentials(
 /** @var $microsoft Microsoft */
 $microsoft = $serviceFactory->createService('microsoft', $credentials, $storage, array('basic'));
 
-if ( !empty( $_GET['code'] ) ) {
-    // This was a callback request from google, get the token
-    $token = $microsoft->requestAccessToken( $_GET['code'] );
+if (!empty($_GET['code'])) {
+    // This was a callback request from Microsoft, get the token
+    $token = $microsoft->requestAccessToken($_GET['code']);
 
     var_dump($token);
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $microsoft->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/paypal.php
+++ b/examples/paypal.php
@@ -1,13 +1,15 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the PayPal service
  *
  * PHP version 5.4
  *
- * @author Flávio Heleno <flaviohbatista@gmail.com>
+ * @author     Flávio Heleno <flaviohbatista@gmail.com>
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\Paypal;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -31,17 +33,17 @@ $credentials = new Credentials(
 /** @var $paypalService PayPal */
 $paypalService = $serviceFactory->createService('paypal', $credentials, $storage, array('profile', 'openid'));
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from PayPal, get the token
-    $token = $paypalService->requestAccessToken( $_GET['code'] );
+    $token = $paypalService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $paypalService->request( '/identity/openidconnect/userinfo/?schema=openid' ), true );
+    $result = json_decode($paypalService->request('/identity/openidconnect/userinfo/?schema=openid'), true);
 
     // Show some of the resultant data
     echo 'Your unique PayPal user id is: ' . $result['user_id'] . ' and your name is ' . $result['name'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $paypalService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/soundcloud.php
+++ b/examples/soundcloud.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the SoundCloud service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth2\Service\SoundCloud;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -32,17 +34,17 @@ $credentials = new Credentials(
 /** @var $soundcloudService SoundCloud */
 $soundcloudService = $serviceFactory->createService('soundCloud', $credentials, $storage);
 
-if ( !empty( $_GET['code'] ) ) {
+if (!empty($_GET['code'])) {
     // This was a callback request from SoundCloud, get the token
-    $soundcloudService->requestAccessToken( $_GET['code'] );
+    $soundcloudService->requestAccessToken($_GET['code']);
 
     // Send a request with it
-    $result = json_decode( $soundcloudService->request( 'me.json' ), true );
+    $result = json_decode($soundcloudService->request('me.json'), true);
 
     // Show some of the resultant data
     echo 'Your unique user id is: ' . $result['id'] . ' and your name is ' . $result['username'];
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     $url = $soundcloudService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/tumblr.php
+++ b/examples/tumblr.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Tumblr service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth1\Service\Tumblr;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -33,23 +35,26 @@ $credentials = new Credentials(
 /** @var $tumblrService Tumblr */
 $tumblrService = $serviceFactory->createService('tumblr', $credentials, $storage);
 
-if ( !empty( $_GET['oauth_token'] ) ) {
-
+if (!empty($_GET['oauth_token'])) {
     $token = $storage->retrieveAccessToken('Tumblr');
 
     // This was a callback request from tumblr, get the token
-    $tumblrService->requestAccessToken($_GET['oauth_token'], $_GET['oauth_verifier'], $token->getRequestTokenSecret());
+    $tumblrService->requestAccessToken(
+        $_GET['oauth_token'],
+        $_GET['oauth_verifier'],
+        $token->getRequestTokenSecret()
+    );
 
     // Send a request now that we have access token
-    $result = json_decode( $tumblrService->request( 'user/info') );
+    $result = json_decode($tumblrService->request('user/info'));
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     // extra request needed for oauth1 to request a request token :-)
     $token = $tumblrService->requestRequestToken();
 
-    $url = $tumblrService->getAuthorizationUri(['oauth_token' => $token->getRequestToken()]);
+    $url = $tumblrService->getAuthorizationUri(array('oauth_token' => $token->getRequestToken()));
     header('Location: ' . $url);
 } else {
     $url = $currentUri->getRelativeUri() . '?go=go';

--- a/examples/twitter.php
+++ b/examples/twitter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Example of retrieving an authentication token of the Twitter service
  *
@@ -9,6 +10,7 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 use OAuth\OAuth1\Service\Twitter;
 use OAuth\Common\Storage\Session;
 use OAuth\Common\Consumer\Credentials;
@@ -33,17 +35,22 @@ $credentials = new Credentials(
 /** @var $twitterService Twitter */
 $twitterService = $serviceFactory->createService('twitter', $credentials, $storage);
 
-if ( !empty( $_GET['oauth_token'] ) ) {
+if (!empty($_GET['oauth_token'])) {
     $token = $storage->retrieveAccessToken('Twitter');
+
     // This was a callback request from twitter, get the token
-    $twitterService->requestAccessToken( $_GET['oauth_token'], $_GET['oauth_verifier'], $token->getRequestTokenSecret() );
+    $twitterService->requestAccessToken(
+        $_GET['oauth_token'],
+        $_GET['oauth_verifier'],
+        $token->getRequestTokenSecret()
+    );
 
     // Send a request now that we have access token
-    $result = json_decode( $twitterService->request( 'account/verify_credentials.json') );
+    $result = json_decode($twitterService->request('account/verify_credentials.json'));
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif ( !empty($_GET['go'] ) && $_GET['go'] == 'go' ) {
+} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
     // extra request needed for oauth1 to request a request token :-)
     $token = $twitterService->requestRequestToken();
 

--- a/src/OAuth/Common/AutoLoader.php
+++ b/src/OAuth/Common/AutoLoader.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace OAuth\Common;
 
 /**
  * PSR-0 Autoloader
+ *
  * @author ieter Hordijk <info@pieterhordijk.com>
  */
 class AutoLoader

--- a/src/OAuth/Common/Consumer/Credentials.php
+++ b/src/OAuth/Common/Consumer/Credentials.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Consumer;
 
 /**

--- a/src/OAuth/Common/Exception/Exception.php
+++ b/src/OAuth/Common/Exception/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Exception;
 
 /**
@@ -6,5 +7,4 @@ namespace OAuth\Common\Exception;
  */
 class Exception extends \Exception
 {
-
 }

--- a/src/OAuth/Common/Http/Client/AbstractClient.php
+++ b/src/OAuth/Common/Http/Client/AbstractClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Client;
 
 /**
@@ -10,7 +11,8 @@ abstract class AbstractClient implements ClientInterface
     protected $timeout      = 15;
 
     /**
-     * @param  int             $maxRedirects Maximum redirects for client
+     * @param int $maxRedirects Maximum redirects for client
+     *
      * @return ClientInterface
      */
     public function setMaxRedirects($redirects)
@@ -21,7 +23,8 @@ abstract class AbstractClient implements ClientInterface
     }
 
     /**
-     * @param  int             $timeout Request timeout time for client in seconds
+     * @param int $timeout Request timeout time for client in seconds
+     *
      * @return ClientInterface
      */
     public function setTimeout($timeout)
@@ -32,17 +35,14 @@ abstract class AbstractClient implements ClientInterface
     }
 
     /**
-     * @param  array $headers
-     * @return void
+     * @param array $headers
      */
     public function normalizeHeaders(&$headers)
     {
         // Normalize headers
-        array_walk( $headers,
-            function(&$val, &$key) {
-                $key = ucfirst( strtolower($key) );
-                $val = ucfirst( strtolower($key) ) . ': ' . $val;
-            }
-        );
+        array_walk($headers, function (&$val, &$key) {
+            $key = ucfirst(strtolower($key));
+            $val = ucfirst(strtolower($key)) . ': ' . $val;
+        });
     }
 }

--- a/src/OAuth/Common/Http/Client/ClientInterface.php
+++ b/src/OAuth/Common/Http/Client/ClientInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Client;
 
 use OAuth\Common\Http\Uri\UriInterface;
@@ -13,12 +14,13 @@ interface ClientInterface
      * Any implementing HTTP providers should send a request to the provided endpoint with the parameters.
      * They should return, in string form, the response body and throw an exception on error.
      *
-     * @abstract
-     * @param  UriInterface           $endpoint
-     * @param  mixed                  $requestBody
-     * @param  array                  $extraHeaders
-     * @param  string                 $method
+     * @param UriInterface $endpoint
+     * @param mixed        $requestBody
+     * @param array        $extraHeaders
+     * @param string       $method
+     *
      * @return string
+     *
      * @throws TokenResponseException
      */
     public function retrieveResponse(UriInterface $endpoint, $requestBody, array $extraHeaders = array(), $method = 'POST');

--- a/src/OAuth/Common/Http/Client/CurlClient.php
+++ b/src/OAuth/Common/Http/Client/CurlClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Client;
 
 use OAuth\Common\Http\Exception\TokenResponseException;
@@ -10,15 +11,16 @@ use OAuth\Common\Http\Uri\UriInterface;
 class CurlClient extends AbstractClient
 {
     /**
-     *  If true, explicitly sets cURL to use SSL version 3. Use this if cURL
-     *  compiles with GnuTLS SSL.
+     * If true, explicitly sets cURL to use SSL version 3. Use this if cURL
+     * compiles with GnuTLS SSL.
      *
-     *  @var bool
+     * @var bool
      */
     private $forceSSL3 = false;
 
     /**
-     * @param  bool       $force
+     * @param bool $force
+     *
      * @return CurlClient
      */
     public function setForceSSL3($force)
@@ -32,11 +34,13 @@ class CurlClient extends AbstractClient
      * Any implementing HTTP providers should send a request to the provided endpoint with the parameters.
      * They should return, in string form, the response body and throw an exception on error.
      *
-     * @param  UriInterface              $endpoint
-     * @param  mixed                     $requestBody
-     * @param  array                     $extraHeaders
-     * @param  string                    $method
+     * @param UriInterface $endpoint
+     * @param mixed        $requestBody
+     * @param array        $extraHeaders
+     * @param string       $method
+     *
      * @return string
+     *
      * @throws TokenResponseException
      * @throws \InvalidArgumentException
      */
@@ -47,11 +51,11 @@ class CurlClient extends AbstractClient
 
         $this->normalizeHeaders($extraHeaders);
 
-        if ( $method === 'GET' && !empty($requestBody) ) {
+        if ($method === 'GET' && !empty($requestBody)) {
             throw new \InvalidArgumentException('No body expected for "GET" request.');
         }
 
-        if ( !isset($extraHeaders['Content-type'] ) && $method === 'POST' && is_array($requestBody) ) {
+        if (!isset($extraHeaders['Content-type']) && $method === 'POST' && is_array($requestBody)) {
             $extraHeaders['Content-type'] = 'Content-type: application/x-www-form-urlencoded';
         }
 
@@ -63,7 +67,7 @@ class CurlClient extends AbstractClient
         curl_setopt($ch, CURLOPT_URL, $endpoint->getAbsoluteUri());
 
         if ($method === 'POST' || $method === 'PUT') {
-            if ( $requestBody && is_array($requestBody) ) {
+            if ($requestBody && is_array($requestBody)) {
                 $requestBody = http_build_query($requestBody, null, '&');
             }
 
@@ -100,9 +104,9 @@ class CurlClient extends AbstractClient
             $errStr = curl_error($ch);
             curl_close($ch);
             if (empty($errStr)) {
-                throw new TokenResponseException( 'Failed to request resource.', $responseCode );
+                throw new TokenResponseException('Failed to request resource.', $responseCode);
             }
-            throw new TokenResponseException( 'cURL Error # '.$errNo.': '.$errStr, $responseCode );
+            throw new TokenResponseException('cURL Error # '.$errNo.': '.$errStr, $responseCode);
         }
 
         curl_close($ch);

--- a/src/OAuth/Common/Http/Client/StreamClient.php
+++ b/src/OAuth/Common/Http/Client/StreamClient.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Client;
 
 use OAuth\Common\Http\Exception\TokenResponseException;
@@ -13,11 +14,13 @@ class StreamClient extends AbstractClient
      * Any implementing HTTP providers should send a request to the provided endpoint with the parameters.
      * They should return, in string form, the response body and throw an exception on error.
      *
-     * @param  UriInterface              $endpoint
-     * @param  mixed                     $requestBody
-     * @param  array                     $extraHeaders
-     * @param  string                    $method
+     * @param UriInterface $endpoint
+     * @param mixed        $requestBody
+     * @param array        $extraHeaders
+     * @param string       $method
+     *
      * @return string
+     *
      * @throws TokenResponseException
      * @throws \InvalidArgumentException
      */
@@ -28,18 +31,18 @@ class StreamClient extends AbstractClient
 
         $this->normalizeHeaders($extraHeaders);
 
-        if ( $method === 'GET' && !empty($requestBody) ) {
+        if ($method === 'GET' && !empty($requestBody)) {
             throw new \InvalidArgumentException('No body expected for "GET" request.');
         }
 
-        if ( !isset($extraHeaders['Content-type'] ) && $method === 'POST' && is_array($requestBody) ) {
+        if (!isset($extraHeaders['Content-type']) && $method === 'POST' && is_array($requestBody)) {
             $extraHeaders['Content-type'] = 'Content-type: application/x-www-form-urlencoded';
         }
 
-        $extraHeaders['Host'] = 'Host: '.$endpoint->getHost();
+        $extraHeaders['Host']       = 'Host: '.$endpoint->getHost();
         $extraHeaders['Connection'] = 'Connection: close';
 
-        if ( is_array($requestBody) ) {
+        if (is_array($requestBody)) {
             $requestBody = http_build_query($requestBody, null, '&');
         }
 
@@ -50,9 +53,10 @@ class StreamClient extends AbstractClient
         error_reporting($level);
         if (false === $response) {
             $lastError = error_get_last();
-            if (is_null($lastError))
-                throw new TokenResponseException( 'Failed to request resource.' );
-            throw new TokenResponseException( $lastError['message'] );
+            if (is_null($lastError)) {
+                throw new TokenResponseException('Failed to request resource.');
+            }
+            throw new TokenResponseException($lastError['message']);
         }
 
         return $response;

--- a/src/OAuth/Common/Http/Exception/TokenResponseException.php
+++ b/src/OAuth/Common/Http/Exception/TokenResponseException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Exception;
 
 use OAuth\Common\Exception\Exception;
@@ -8,5 +9,4 @@ use OAuth\Common\Exception\Exception;
  */
 class TokenResponseException extends Exception
 {
-
 }

--- a/src/OAuth/Common/Http/Uri/Uri.php
+++ b/src/OAuth/Common/Http/Uri/Uri.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Uri;
 
 use InvalidArgumentException;
@@ -12,30 +13,37 @@ class Uri implements UriInterface
      * @var string
      */
     private $scheme = 'http';
+
     /**
      * @var string
      */
     private $userInfo = '';
+
     /**
      * @var string
      */
     private $rawUserInfo = '';
+
     /**
      * @var string
      */
     private $host;
+
     /**
      * @var int
      */
     private $port = 80;
+
     /**
      * @var string
      */
     private $path = '/';
+
     /**
      * @var string
      */
     private $query = '';
+
     /**
      * @var string
      */
@@ -45,6 +53,7 @@ class Uri implements UriInterface
      * @var bool
      */
     private $explicitPortSpecified = false;
+
     /**
      * @var bool
      */
@@ -61,22 +70,19 @@ class Uri implements UriInterface
     }
 
     /**
-     * @param  string                    $uri
+     * @param string $uri
+     *
      * @throws \InvalidArgumentException
      */
     protected function parseUri($uri)
     {
-        if ( false === ( $uriParts = parse_url($uri) ) ) {
+        if (false === ($uriParts = parse_url($uri))) {
             // congratulations if you've managed to get parse_url to fail, it seems to always return some semblance of a parsed url no matter what
-            throw new InvalidArgumentException(
-                "Invalid URI: $uri"
-            );
+            throw new InvalidArgumentException("Invalid URI: $uri");
         }
 
         if (!isset($uriParts['scheme'])) {
-            throw new InvalidArgumentException(
-                'Invalid URI: http|https scheme required'
-            );
+            throw new InvalidArgumentException('Invalid URI: http|https scheme required');
         }
 
         $this->scheme = $uriParts['scheme'];
@@ -114,7 +120,8 @@ class Uri implements UriInterface
     }
 
     /**
-     * @param  string $rawUserInfo
+     * @param string $rawUserInfo
+     *
      * @return string
      */
     protected function protectUserInfo($rawUserInfo)
@@ -126,7 +133,7 @@ class Uri implements UriInterface
         // after the first colon (":") character found within a userinfo
         // subcomponent unless the data after the colon is the empty string
         // (indicating no password)"
-        if ($colonPos !== FALSE && strlen($rawUserInfo)-1 > $colonPos) {
+        if ($colonPos !== false && strlen($rawUserInfo)-1 > $colonPos) {
             return substr($rawUserInfo, 0, $colonPos) . ':********';
         } else {
             return $rawUserInfo;
@@ -302,7 +309,7 @@ class Uri implements UriInterface
      */
     public function setPath($path)
     {
-        if ( empty($path) ) {
+        if (empty($path)) {
             $this->path = '/';
             $this->explicitTrailingHostSlash = false;
         } else {
@@ -327,10 +334,10 @@ class Uri implements UriInterface
      */
     public function addToQuery($var, $val)
     {
-        if ( strlen($this->query) > 0 ) {
+        if (strlen($this->query) > 0) {
             $this->query .= '&';
         }
-        $this->query .= http_build_query( array($var => $val) );
+        $this->query .= http_build_query(array($var => $val));
     }
 
     /**
@@ -367,7 +374,7 @@ class Uri implements UriInterface
     {
         $this->port = intval($port);
 
-        if ( ( 'https' === $this->scheme && $this->port === 443 ) || ( 'http' === $this->scheme && $this->port === 80 ) ) {
+        if (('https' === $this->scheme && $this->port === 443) || ('http' === $this->scheme && $this->port === 80)) {
             $this->explicitPortSpecified = false;
         } else {
             $this->explicitPortSpecified = true;

--- a/src/OAuth/Common/Http/Uri/UriFactory.php
+++ b/src/OAuth/Common/Http/Uri/UriFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Uri;
 
 use RuntimeException;
@@ -10,7 +11,9 @@ class UriFactory implements UriFactoryInterface
 {
     /**
      * Factory method to build a URI from a super-global $_SERVER array.
-     * @param  array        $_server
+     *
+     * @param array $_server
+     *
      * @return UriInterface
      */
     public function createFromSuperGlobalArray(array $_server)
@@ -29,7 +32,8 @@ class UriFactory implements UriFactoryInterface
     }
 
     /**
-     * @param  string       $absoluteUri
+     * @param string $absoluteUri
+     *
      * @return UriInterface
      */
     public function createFromAbsolute($absoluteUri)
@@ -40,13 +44,14 @@ class UriFactory implements UriFactoryInterface
     /**
      * Factory method to build a URI from parts
      *
-     * @param  string       $scheme
-     * @param  string       $userInfo
-     * @param  string       $host
-     * @param  string       $port
-     * @param  string       $path
-     * @param  string       $query
-     * @param  string       $fragment
+     * @param string $scheme
+     * @param string $userInfo
+     * @param string $host
+     * @param string $port
+     * @param string $path
+     * @param string $query
+     * @param string $fragment
+     *
      * @return UriInterface
      */
     public function createFromParts($scheme, $userInfo, $host, $port, $path = '', $query = '', $fragment = '')
@@ -64,7 +69,8 @@ class UriFactory implements UriFactoryInterface
     }
 
     /**
-     * @param  array             $_server
+     * @param array $_server
+     *
      * @return UriInterface|null
      */
     private function attemptProxyStyleParse($_server)
@@ -80,8 +86,10 @@ class UriFactory implements UriFactoryInterface
     }
 
     /**
-     * @param  array            $_server
+     * @param array $_server
+     *
      * @return string
+     *
      * @throws RuntimeException
      */
     private function detectPath($_server)
@@ -91,7 +99,7 @@ class UriFactory implements UriFactoryInterface
         } elseif (isset($_server['REDIRECT_URL'])) {
             $uri = $_server['REDIRECT_URL'];
         } else {
-            throw new RuntimeException("Could not detect URI path from superglobal");
+            throw new RuntimeException('Could not detect URI path from superglobal');
         }
 
         $queryStr = strpos($uri, '?');
@@ -103,7 +111,8 @@ class UriFactory implements UriFactoryInterface
     }
 
     /**
-     * @param  array  $_server
+     * @param array $_server
+     *
      * @return string
      */
     private function detectHost(array $_server)
@@ -118,7 +127,8 @@ class UriFactory implements UriFactoryInterface
     }
 
     /**
-     * @param  array  $_server
+     * @param array $_server
+     *
      * @return string
      */
     private function detectPort(array $_server)
@@ -127,7 +137,8 @@ class UriFactory implements UriFactoryInterface
     }
 
     /**
-     * @param  array  $_server
+     * @param array $_server
+     *
      * @return string
      */
     private function detectQuery(array $_server)
@@ -148,9 +159,7 @@ class UriFactory implements UriFactoryInterface
      */
     private function detectScheme(array $_server)
     {
-        if (isset($_server['HTTPS'])
-            && filter_var($_server['HTTPS'], FILTER_VALIDATE_BOOLEAN)
-        ) {
+        if (isset($_server['HTTPS']) && filter_var($_server['HTTPS'], FILTER_VALIDATE_BOOLEAN)) {
             return 'https';
         } else {
             return 'http';

--- a/src/OAuth/Common/Http/Uri/UriFactoryInterface.php
+++ b/src/OAuth/Common/Http/Uri/UriFactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Http\Uri;
 
 /**
@@ -9,8 +10,8 @@ interface UriFactoryInterface
     /**
      * Factory method to build a URI from a super-global $_SERVER array.
      *
-     * @abstract
-     * @param  array        $_server
+     * @param array $_server
+     *
      * @return UriInterface
      */
     public function createFromSuperGlobalArray(array $_server);
@@ -18,8 +19,8 @@ interface UriFactoryInterface
     /**
      * Creates a URI from an absolute URI
      *
-     * @abstract
-     * @param  string       $absoluteUri
+     * @param string $absoluteUri
+     *
      * @return UriInterface
      */
     public function createFromAbsolute($absoluteUri);
@@ -27,14 +28,14 @@ interface UriFactoryInterface
     /**
      * Factory method to build a URI from parts
      *
-     * @abstract
-     * @param  string       $scheme
-     * @param  string       $userInfo
-     * @param  string       $host
-     * @param  string       $port
-     * @param  string       $path
-     * @param  string       $query
-     * @param  string       $fragment
+     * @param string $scheme
+     * @param string $userInfo
+     * @param string $host
+     * @param string $port
+     * @param string $path
+     * @param string $query
+     * @param string $fragment
+     *
      * @return UriInterface
      */
     public function createFromParts($scheme, $userInfo, $host, $port, $path = '', $query = '', $fragment = '');

--- a/src/OAuth/Common/Http/Uri/UriInterface.php
+++ b/src/OAuth/Common/Http/Uri/UriInterface.php
@@ -1,64 +1,55 @@
 <?php
+
 namespace OAuth\Common\Http\Uri;
 
 interface UriInterface
 {
     /**
-     * @abstract
      * @return string
      */
     public function getScheme();
 
     /**
-     * @abstract
      * @param string $scheme
      */
     public function setScheme($scheme);
 
     /**
-     * @abstract
      * @return string
      */
     public function getHost();
 
     /**
-     * @abstract
      * @param string $host
      */
     public function setHost($host);
 
     /**
-     * @abstract
      * @return int
      */
     public function getPort();
 
     /**
-     * @abstract
      * @param int $port
      */
     public function setPort($port);
 
     /**
-     * @abstract
      * @return string
      */
     public function getPath();
 
     /**
-     * @abstract
      * @param string $path
      */
     public function setPath($path);
 
     /**
-     * @abstract
      * @return string
      */
     public function getQuery();
 
     /**
-     * @abstract
      * @param string $query
      */
     public function setQuery($query);
@@ -66,14 +57,12 @@ interface UriInterface
     /**
      * Adds a param to the query string.
      *
-     * @abstract
      * @param string $var
      * @param string $val
      */
     public function addToQuery($var, $val);
 
     /**
-     * @abstract
      * @return string
      */
     public function getFragment();
@@ -81,13 +70,11 @@ interface UriInterface
     /**
      * Should return URI user info, masking protected user info data according to rfc3986-3.2.1
      *
-     * @abstract
      * @return string
      */
     public function getUserInfo();
 
     /**
-     * @abstract
      * @param string $userInfo
      */
     public function setUserInfo($userInfo);
@@ -95,7 +82,6 @@ interface UriInterface
     /**
      * Should return the URI Authority, masking protected user info data according to rfc3986-3.2.1
      *
-     * @abstract
      * @return string
      */
     public function getAuthority();
@@ -103,7 +89,6 @@ interface UriInterface
     /**
      * Should return the URI string, masking protected user info data according to rfc3986-3.2.1
      *
-     * @abstract
      * @return string the URI string with user protected info masked
      */
     public function __toString();
@@ -111,7 +96,6 @@ interface UriInterface
     /**
      * Should return the URI Authority without masking protected user info data
      *
-     * @abstract
      * @return string
      */
     public function getRawAuthority();
@@ -119,7 +103,6 @@ interface UriInterface
     /**
      * Should return the URI user info without masking protected user info data
      *
-     * @abstract
      * @return string
      */
     public function getRawUserInfo();
@@ -127,7 +110,6 @@ interface UriInterface
     /**
      * Build the full URI based on all the properties
      *
-     * @abstract
      * @return string The full URI without masking user info
      */
     public function getAbsoluteUri();
@@ -135,7 +117,6 @@ interface UriInterface
     /**
      * Build the relative URI based on all the properties
      *
-     * @abstract
      * @return string The relative URI
      */
     public function getRelativeUri();
@@ -144,5 +125,4 @@ interface UriInterface
      * @return bool
      */
     public function hasExplicitTrailingHostSlash();
-
 }

--- a/src/OAuth/Common/Service/AbstractService.php
+++ b/src/OAuth/Common/Service/AbstractService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Service;
 
 use OAuth\Common\Consumer\Credentials;
@@ -13,32 +14,40 @@ use OAuth\Common\Storage\TokenStorageInterface;
  */
 abstract class AbstractService implements ServiceInterface
 {
-    /** @var \OAuth\Common\Consumer\Credentials */
+    /** @var Credentials */
     protected $credentials;
 
-    /** @var \OAuth\Common\Http\Client\ClientInterface */
+    /** @var ClientInterface */
     protected $httpClient;
 
-    /** @var \OAuth\Common\Storage\TokenStorageInterface */
+    /** @var TokenStorageInterface */
     protected $storage;
 
     /**
-     * @param \OAuth\Common\Consumer\Credentials          $credentials
-     * @param \OAuth\Common\Http\Client\ClientInterface   $httpClient
-     * @param \OAuth\Common\Storage\TokenStorageInterface $storage
+     * @param Credentials           $credentials
+     * @param ClientInterface       $httpClient
+     * @param TokenStorageInterface $storage
      */
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage)
     {
         $this->credentials = $credentials;
-        $this->httpClient   = $httpClient;
+        $this->httpClient = $httpClient;
         $this->storage = $storage;
     }
 
+    /**
+     * @param UriInterface|string $path
+     * @param UriInterface        $baseApiUri
+     *
+     * @return UriInterface
+     *
+     * @throws Exception
+     */
     protected function determineRequestUriFromPath($path, UriInterface $baseApiUri = null)
     {
         if ($path instanceof UriInterface) {
             $uri = $path;
-        } elseif ( stripos($path, 'http://') === 0 || stripos($path, 'https://') === 0 ) {
+        } elseif (stripos($path, 'http://') === 0 || stripos($path, 'https://') === 0) {
             $uri = new Uri($path);
         } else {
             if (null === $baseApiUri) {
@@ -46,7 +55,7 @@ abstract class AbstractService implements ServiceInterface
             }
 
             $uri = clone $baseApiUri;
-            if ( false !== strpos($path, '?') ) {
+            if (false !== strpos($path, '?')) {
                 $parts = explode('?', $path, 2);
                 $path = $parts[0];
                 $query = $parts[1];
@@ -64,9 +73,10 @@ abstract class AbstractService implements ServiceInterface
     }
 
     /**
-    * Accessor to the storage adapter to be able to retrieve tokens
-    *
-    */
+     * Accessor to the storage adapter to be able to retrieve tokens
+     *
+     * @return TokenStorageInterface
+     */
     public function getStorage()
     {
         return $this->storage;

--- a/src/OAuth/Common/Service/ServiceInterface.php
+++ b/src/OAuth/Common/Service/ServiceInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Service;
 
 use OAuth\Common\Http\Uri\UriInterface;
@@ -12,11 +13,11 @@ interface ServiceInterface
      * Sends an authenticated API request to the path provided.
      * If the path provided is not an absolute URI, the base API Uri (service-specific) will be used.
      *
-     * @abstract
-     * @param $path string|UriInterface
-     * @param  string $method       HTTP method
-     * @param  array  $body         Request body if applicable (an associative array will automatically be converted into a urlencoded body)
-     * @param  array  $extraHeaders Extra headers if applicable. These will override service-specific any defaults.
+     * @param string|UriInterface $path
+     * @param string              $method       HTTP method
+     * @param array               $body         Request body if applicable (an associative array will automatically be converted into a urlencoded body)
+     * @param array               $extraHeaders Extra headers if applicable. These will override service-specific any defaults.
+     *
      * @return string
      */
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array());
@@ -24,16 +25,15 @@ interface ServiceInterface
     /**
      * Returns the url to redirect to for authorization purposes.
      *
-     * @abstract
-     * @param  array        $additionalParameters
+     * @param array $additionalParameters
+     *
      * @return UriInterface
      */
-    public function getAuthorizationUri( array $additionalParameters = array() );
+    public function getAuthorizationUri(array $additionalParameters = array());
 
     /**
      * Returns the authorization API endpoint.
      *
-     * @abstract
      * @return UriInterface
      */
     public function getAuthorizationEndpoint();
@@ -41,7 +41,6 @@ interface ServiceInterface
     /**
      * Returns the access token API endpoint.
      *
-     * @abstract
      * @return UriInterface
      */
     public function getAccessTokenEndpoint();

--- a/src/OAuth/Common/Storage/Exception/StorageException.php
+++ b/src/OAuth/Common/Storage/Exception/StorageException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Storage\Exception;
 
 use OAuth\Common\Exception\Exception;
@@ -8,5 +9,4 @@ use OAuth\Common\Exception\Exception;
  */
 class StorageException extends Exception
 {
-
 }

--- a/src/OAuth/Common/Storage/Exception/TokenNotFoundException.php
+++ b/src/OAuth/Common/Storage/Exception/TokenNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Storage\Exception;
 
 /**
@@ -6,5 +7,4 @@ namespace OAuth\Common\Storage\Exception;
  */
 class TokenNotFoundException extends StorageException
 {
-
 }

--- a/src/OAuth/Common/Storage/Memory.php
+++ b/src/OAuth/Common/Storage/Memory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Storage;
 
 use OAuth\Common\Token\TokenInterface;
@@ -20,8 +21,7 @@ class Memory implements TokenStorageInterface
     }
 
     /**
-     * @return \OAuth\Common\Token\TokenInterface
-     * @throws TokenNotFoundException
+     * {@inheritDoc}
      */
     public function retrieveAccessToken($service)
     {
@@ -33,7 +33,7 @@ class Memory implements TokenStorageInterface
     }
 
     /**
-     * @param \OAuth\Common\Token\TokenInterface $token
+     * {@inheritDoc}
      */
     public function storeAccessToken($service, TokenInterface $token)
     {
@@ -44,16 +44,16 @@ class Memory implements TokenStorageInterface
     }
 
     /**
-    * @return bool
-    */
+     * {@inheritDoc}
+     */
     public function hasAccessToken($service)
     {
-        return isset($this->tokens[$service]) &&
-               $this->tokens[$service] instanceOf TokenInterface;
+        return isset($this->tokens[$service])
+            && $this->tokens[$service] instanceOf TokenInterface;
     }
 
     /**
-     * Delete the user's token. Aka, log out.
+     * {@inheritDoc}
      */
     public function clearToken($service)
     {
@@ -66,8 +66,7 @@ class Memory implements TokenStorageInterface
     }
 
     /**
-     * Delete *ALL* user tokens. Use with care. Most of the time you will likely
-     * want to use clearToken() instead.
+     * {@inheritDoc}
      */
     public function clearAllTokens()
     {

--- a/src/OAuth/Common/Storage/Redis.php
+++ b/src/OAuth/Common/Storage/Redis.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace OAuth\Common\Storage;
 
 use OAuth\Common\Token\TokenInterface;
-use OAuth\Common\Storage\Exception\StorageException;
 use OAuth\Common\Storage\Exception\TokenNotFoundException;
 use Predis\Client as Predis;
 
@@ -38,8 +38,7 @@ class Redis implements TokenStorageInterface
     }
 
     /**
-     * @return \OAuth\Common\Token\TokenInterface
-     * @throws TokenNotFoundException
+     * {@inheritDoc}
      */
     public function retrieveAccessToken($service)
     {
@@ -57,8 +56,7 @@ class Redis implements TokenStorageInterface
     }
 
     /**
-     * @param  \OAuth\Common\Token\TokenInterface $token
-     * @throws StorageException
+     * {@inheritDoc}
      */
     public function storeAccessToken($service, TokenInterface $token)
     {
@@ -71,13 +69,13 @@ class Redis implements TokenStorageInterface
     }
 
     /**
-    * @return bool
-    */
+     * {@inheritDoc}
+     */
     public function hasAccessToken($service)
     {
-        if (isset($this->cachedTokens[$service]) &&
-            $this->cachedTokens[$service] instanceof TokenInterface)
-        {
+        if (isset($this->cachedTokens[$service])
+            && $this->cachedTokens[$service] instanceof TokenInterface
+        ) {
             return true;
         }
 
@@ -85,7 +83,7 @@ class Redis implements TokenStorageInterface
     }
 
     /**
-     * Delete the user's token. Aka, log out.
+     * {@inheritDoc}
      */
     public function clearToken($service)
     {
@@ -97,8 +95,7 @@ class Redis implements TokenStorageInterface
     }
 
     /**
-     * Delete *ALL* user tokens. Use with care. Most of the time you will likely
-     * want to use clearToken() instead.
+     * {@inheritDoc}
      */
     public function clearAllTokens()
     {
@@ -110,14 +107,10 @@ class Redis implements TokenStorageInterface
         $me = $this; // 5.3 compat
 
         // pipeline for performance
-        $this->redis->pipeline(function($pipe) use ($keys, $me) {
-
+        $this->redis->pipeline(function ($pipe) use ($keys, $me) {
             foreach ($keys as $k) {
-
                 $pipe->hdel($me->getKey(), $k);
-
             }
-
         });
 
         // allow chaining

--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Storage;
 
 use OAuth\Common\Token\TokenInterface;
@@ -20,7 +21,7 @@ class Session implements TokenStorageInterface
      */
     public function __construct($startSession = true, $sessionVariableName = 'lusitanian_oauth_token')
     {
-        if ( $startSession && !isset($_SESSION)) {
+        if ($startSession && !isset($_SESSION)) {
             session_start();
         }
 
@@ -31,8 +32,7 @@ class Session implements TokenStorageInterface
     }
 
     /**
-     * @return \OAuth\Common\Token\TokenInterface
-     * @throws TokenNotFoundException
+     * {@inheritDoc}
      */
     public function retrieveAccessToken($service)
     {
@@ -44,13 +44,13 @@ class Session implements TokenStorageInterface
     }
 
     /**
-     * @param \OAuth\Common\Token\TokenInterface $token
+     * {@inheritDoc}
      */
     public function storeAccessToken($service, TokenInterface $token)
     {
-        if (isset($_SESSION[$this->sessionVariableName]) &&
-            is_array($_SESSION[$this->sessionVariableName]))
-        {
+        if (isset($_SESSION[$this->sessionVariableName])
+            && is_array($_SESSION[$this->sessionVariableName])
+        ) {
             $_SESSION[$this->sessionVariableName][$service] = $token;
         } else {
             $_SESSION[$this->sessionVariableName] = array(
@@ -63,15 +63,15 @@ class Session implements TokenStorageInterface
     }
 
     /**
-    * @return bool
-    */
+     * {@inheritDoc}
+     */
     public function hasAccessToken($service)
     {
         return isset($_SESSION[$this->sessionVariableName], $_SESSION[$this->sessionVariableName][$service]);
     }
 
     /**
-     * Delete the user's token. Aka, log out.
+     * {@inheritDoc}
      */
     public function clearToken($service)
     {
@@ -84,8 +84,7 @@ class Session implements TokenStorageInterface
     }
 
     /**
-     * Delete *ALL* user tokens. Use with care. Most of the time you will likely
-     * want to use clearToken() instead.
+     * {@inheritDoc}
      */
     public function clearAllTokens()
     {

--- a/src/OAuth/Common/Storage/SymfonySession.php
+++ b/src/OAuth/Common/Storage/SymfonySession.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Storage;
 
 use OAuth\Common\Token\TokenInterface;
@@ -17,8 +18,7 @@ class SymfonySession implements TokenStorageInterface
     }
 
     /**
-     * @return \OAuth\Common\Token\TokenInterface
-     * @throws TokenNotFoundException
+     * {@inheritDoc}
      */
     public function retrieveAccessToken($service)
     {
@@ -33,6 +33,9 @@ class SymfonySession implements TokenStorageInterface
         throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function storeAccessToken($service, TokenInterface $token)
     {
         // get previously saved tokens
@@ -52,20 +55,20 @@ class SymfonySession implements TokenStorageInterface
     }
 
     /**
-    * @return bool
-    */
+     * {@inheritDoc}
+     */
     public function hasAccessToken($service)
     {
         // get from session
         $tokens = $this->session->get($this->sessionVariableName);
 
-        return is_array($tokens) &&
-               isset($tokens[$service]) &&
-               $tokens[$service] instanceof TokenInterface;
+        return is_array($tokens)
+            && isset($tokens[$service])
+            && $tokens[$service] instanceof TokenInterface;
     }
 
     /**
-     * Delete the user's token. Aka, log out.
+     * {@inheritDoc}
      */
     public function clearToken($service)
     {
@@ -84,8 +87,7 @@ class SymfonySession implements TokenStorageInterface
     }
 
     /**
-     * Delete *ALL* user tokens. Use with care. Most of the time you will likely
-     * want to use clearToken() instead.
+     * {@inheritDoc}
      */
     public function clearAllTokens()
     {

--- a/src/OAuth/Common/Storage/TokenStorageInterface.php
+++ b/src/OAuth/Common/Storage/TokenStorageInterface.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace OAuth\Common\Storage;
 
 use OAuth\Common\Token\TokenInterface;
+use OAuth\Common\Storage\Exception\TokenNotFoundException;
 
 /**
  * All token storage providers must implement this interface.
@@ -9,20 +11,25 @@ use OAuth\Common\Token\TokenInterface;
 interface TokenStorageInterface
 {
     /**
-     * @param  string                             $service
-     * @return \OAuth\Common\Token\TokenInterface
+     * @param string $service
+     *
+     * @return TokenInterface
+     *
+     * @throws TokenNotFoundException
      */
     public function retrieveAccessToken($service);
 
     /**
-     * @param  string                             $service
-     * @param  \OAuth\Common\Token\TokenInterface $token
-     * @return \OAuth\Common\Token\TokenInterface
+     * @param string         $service
+     * @param TokenInterface $token
+     *
+     * @return TokenStorageInterface
      */
     public function storeAccessToken($service, TokenInterface $token);
 
     /**
-     * @param  string $service
+     * @param string $service
+     *
      * @return bool
      */
     public function hasAccessToken($service);
@@ -30,13 +37,15 @@ interface TokenStorageInterface
     /**
      * Delete the users token. Aka, log out.
      *
-     * @param  string                $service
+     * @param string $service
+     *
      * @return TokenStorageInterface
      */
     public function clearToken($service);
 
     /**
-     * Delete *ALL* user tokens.
+     * Delete *ALL* user tokens. Use with care. Most of the time you will likely
+     * want to use clearToken() instead.
      *
      * @return TokenStorageInterface
      */

--- a/src/OAuth/Common/Token/AbstractToken.php
+++ b/src/OAuth/Common/Token/AbstractToken.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Token;
 
 /**
@@ -32,7 +33,7 @@ abstract class AbstractToken implements TokenInterface
      * @param int    $lifetime
      * @param array  $extraParams
      */
-    public function __construct($accessToken = null, $refreshToken = null, $lifetime = null, $extraParams = array() )
+    public function __construct($accessToken = null, $refreshToken = null, $lifetime = null, $extraParams = array())
     {
         $this->accessToken = $accessToken;
         $this->refreshToken = $refreshToken;
@@ -97,7 +98,7 @@ abstract class AbstractToken implements TokenInterface
     }
 
     /**
-     * @param $lifetime
+     * @param int $lifetime
      */
     public function setLifetime($lifetime)
     {

--- a/src/OAuth/Common/Token/Exception/ExpiredTokenException.php
+++ b/src/OAuth/Common/Token/Exception/ExpiredTokenException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Token\Exception;
 
 use OAuth\Common\Exception\Exception;
@@ -8,5 +9,4 @@ use OAuth\Common\Exception\Exception;
  */
 class ExpiredTokenException extends Exception
 {
-
 }

--- a/src/OAuth/Common/Token/TokenInterface.php
+++ b/src/OAuth/Common/Token/TokenInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Common\Token;
 
 /**
@@ -16,59 +17,50 @@ interface TokenInterface
      */
     const EOL_NEVER_EXPIRES = -9002;
 
-    public function __construct($accessToken = null, $refreshToken = null, $lifetime = null, $extraParams = array() );
+    public function __construct($accessToken = null, $refreshToken = null, $lifetime = null, $extraParams = array());
 
     /**
-     * @abstract
      * @return string
      */
     public function getAccessToken();
 
     /**
-     * @abstract
      * @return int
      */
     public function getEndOfLife();
 
     /**
-     * @abstract
      * @return array
      */
     public function getExtraParams();
 
     /**
-     * @abstract
-     * @param $accessToken
+     * @param string $accessToken
      */
     public function setAccessToken($accessToken);
 
     /**
-     * @abstract
+     * @param int $endOfLife
      */
     public function setEndOfLife($endOfLife);
 
     /**
-     * @abstract
-     * @param $lifetime
+     * @param int $lifetime
      */
     public function setLifetime($lifetime);
 
     /**
-     * @abstract
      * @param array $extraParams
      */
     public function setExtraParams(array $extraParams);
 
     /**
-     * @abstract
      * @return string
      */
     public function getRefreshToken();
 
     /**
-     * @abstract
      * @param string $refreshToken
      */
     public function setRefreshToken($refreshToken);
-
 }

--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\Common\Consumer\Credentials;
@@ -13,38 +14,30 @@ use OAuth\Common\Service\AbstractService as BaseAbstractService;
 
 abstract class AbstractService extends BaseAbstractService implements ServiceInterface
 {
-
     /** @const OAUTH_VERSION */
     const OAUTH_VERSION = 1;
 
-    /** @var \OAuth\OAuth1\Signature\SignatureInterface */
+    /** @var SignatureInterface */
     protected $signature;
 
-    /** @var \OAuth\Common\Http\Uri\UriInterface|null */
+    /** @var UriInterface|null */
     protected $baseApiUri;
 
     /**
-     * @param \OAuth\Common\Consumer\Credentials          $credentials
-     * @param \OAuth\Common\Http\Client\ClientInterface   $httpClient
-     * @param \OAuth\Common\Storage\TokenStorageInterface $storage
-     * @param \OAuth\OAuth1\Signature\SignatureInterface  $signature
-     * @param UriInterface|null                           $baseApiUri
+     * {@inheritDoc}
      */
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage);
 
-        $this->signature    = $signature;
-        $this->baseApiUri   = $baseApiUri;
+        $this->signature = $signature;
+        $this->baseApiUri = $baseApiUri;
 
         $this->signature->setHashingAlgorithm($this->getSignatureMethod());
     }
 
     /**
-     * Retrieves and stores the OAuth1 request token obtained from the service.
-     *
-     * @return TokenInterface         $token
-     * @throws TokenResponseException
+     * {@inheritDoc}
      */
     public function requestRequestToken()
     {
@@ -60,12 +53,9 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     }
 
     /**
-     * Returns the url to redirect to for authorization purposes.
-     *
-     * @param  array  $additionalParameters
-     * @return string
+     * {@inheritdoc}
      */
-    public function getAuthorizationUri( array $additionalParameters = array() )
+    public function getAuthorizationUri(array $additionalParameters = array())
     {
         // Build the url
         $url = clone $this->getAuthorizationEndpoint();
@@ -77,14 +67,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     }
 
     /**
-     * Retrieves and stores/returns the OAuth1 access token after a successful authorization.
-     *
-     * @abstract
-     * @param  string                 $token       The request token from the callback.
-     * @param  string                 $verifier
-     * @param  string                 $tokenSecret
-     * @return TokenInterface         $token
-     * @throws TokenResponseException
+     * {@inheritDoc}
      */
     public function requestAccessToken($token, $verifier, $tokenSecret = null)
     {
@@ -103,12 +86,11 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         );
 
         $authorizationHeader = array(
-            'Authorization' =>
-                $this->buildAuthorizationHeaderForAPIRequest(
-                    'POST',
-                    $this->getAccessTokenEndpoint(),
-                    $this->storage->retrieveAccessToken($this->service()),
-                    $bodyParams
+            'Authorization' => $this->buildAuthorizationHeaderForAPIRequest(
+                'POST',
+                $this->getAccessTokenEndpoint(),
+                $this->storage->retrieveAccessToken($this->service()),
+                $bodyParams
             )
         );
 
@@ -125,19 +107,21 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /**
      * Sends an authenticated API request to the path provided.
      * If the path provided is not an absolute URI, the base API Uri (must be passed into constructor) will be used.
-     * @param $path string|UriInterface
-     * @param  string $method       HTTP method
-     * @param  array  $body         Request body if applicable (key/value pairs)
-     * @param  array  $extraHeaders Extra headers if applicable. These will override service-specific any defaults.
+     *
+     * @param string|UriInterface $path
+     * @param string              $method       HTTP method
+     * @param array               $body         Request body if applicable (key/value pairs)
+     * @param array               $extraHeaders Extra headers if applicable. These will override service-specific any defaults.
+     *
      * @return string
      */
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $uri = $this->determineRequestUriFromPath($path, $this->baseApiUri);
 
-        /** @var $token \OAuth\OAuth1\Token\StdOAuth1Token */
+        /** @var $token StdOAuth1Token */
         $token = $this->storage->retrieveAccessToken($this->service());
-        $extraHeaders = array_merge( $this->getExtraApiHeaders(), $extraHeaders );
+        $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);
         $authorizationHeader = array('Authorization' => $this->buildAuthorizationHeaderForAPIRequest($method, $uri, $token, $body));
         $headers = array_merge($authorizationHeader, $extraHeaders);
 
@@ -167,7 +151,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /**
      * Builds the authorization header for getting an access or request token.
      *
-     * @param  array  $extraParameters
+     * @param array $extraParameters
+     *
      * @return string
      */
     protected function buildAuthorizationHeaderForTokenRequest(array $extraParameters = array())
@@ -189,21 +174,23 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
 
     /**
      * Builds the authorization header for an authenticated API request
-     * @param string                             $method
-     * @param UriInterface                       $uri    the uri the request is headed
-     * @param \OAuth\OAuth1\Token\TokenInterface $token
-     * @param $bodyParams Request body if applicable (key/value pairs)
+     *
+     * @param string         $method
+     * @param UriInterface   $uri        The uri the request is headed
+     * @param TokenInterface $token
+     * @param array          $bodyParams Request body if applicable (key/value pairs)
+     *
      * @return string
      */
     protected function buildAuthorizationHeaderForAPIRequest($method, UriInterface $uri, TokenInterface $token, $bodyParams = null)
     {
         $this->signature->setTokenSecret($token->getAccessTokenSecret());
         $parameters = $this->getBasicAuthorizationHeaderInfo();
-        if ( isset($parameters['oauth_callback'] ) ) {
+        if (isset($parameters['oauth_callback'])) {
             unset($parameters['oauth_callback']);
         }
 
-        $parameters = array_merge($parameters, array('oauth_token' => $token->getAccessToken()) );
+        $parameters = array_merge($parameters, array('oauth_token' => $token->getAccessToken()));
 
         $mergedParams = (is_array($bodyParams)) ? array_merge($parameters, $bodyParams) : $parameters;
 
@@ -243,7 +230,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /**
      * Pseudo random string generator used to build a unique string to sign each request
      *
-     * @param  int    $length
+     * @param int $length
+     *
      * @return string
      */
     protected function generateNonce($length = 32)
@@ -279,10 +267,16 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
 
     /**
      * Parses the request token response and returns a TokenInterface.
+     * This is only needed to verify the `oauth_callback_confirmed` parameter. The actual
+     * parsing logic is contained in the access token parser.
      *
      * @abstract
-     * @return \OAuth\OAuth1\Token\TokenInterface
-     * @param  string                             $responseBody
+     *
+     * @param string $responseBody
+     *
+     * @return TokenInterface
+     *
+     * @throws TokenResponseException
      */
     abstract protected function parseRequestTokenResponse($responseBody);
 
@@ -290,8 +284,12 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * Parses the access token response and returns a TokenInterface.
      *
      * @abstract
-     * @return \OAuth\OAuth1\Token\TokenInterface
-     * @param  string                             $responseBody
+     *
+     * @param string $responseBody
+     *
+     * @return TokenInterface
+     *
+     * @throws TokenResponseException
      */
     abstract protected function parseAccessTokenResponse($responseBody);
 }

--- a/src/OAuth/OAuth1/Service/BitBucket.php
+++ b/src/OAuth/OAuth1/Service/BitBucket.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
@@ -15,13 +16,14 @@ class BitBucket extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://bitbucket.org/api/1.0/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritDoc}
      */
     public function getRequestTokenEndpoint()
     {
@@ -29,7 +31,7 @@ class BitBucket extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -37,7 +39,7 @@ class BitBucket extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -45,18 +47,13 @@ class BitBucket extends AbstractService
     }
 
     /**
-     * We need a separate request token parser only to verify the `oauth_callback_confirmed` parameter. For the actual
-     * parsing we can just use the default access token parser.
-     *
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseRequestTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
             throw new TokenResponseException('Error in retrieving token.');
@@ -66,31 +63,28 @@ class BitBucket extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken( $data['oauth_token'] );
-        $token->setRequestTokenSecret( $data['oauth_token_secret'] );
-        $token->setAccessToken( $data['oauth_token'] );
-        $token->setAccessTokenSecret( $data['oauth_token_secret'] );
+        $token->setRequestToken($data['oauth_token']);
+        $token->setRequestTokenSecret($data['oauth_token_secret']);
+        $token->setAccessToken($data['oauth_token']);
+        $token->setAccessTokenSecret($data['oauth_token_secret']);
 
         $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset( $data['oauth_token'], $data['oauth_token_secret'] );
-        $token->setExtraParams( $data );
+        unset($data['oauth_token'], $data['oauth_token_secret']);
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
@@ -15,13 +16,14 @@ class Etsy extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('http://openapi.etsy.com/v2/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getRequestTokenEndpoint()
     {
@@ -29,8 +31,7 @@ class Etsy extends AbstractService
     }
 
     /**
-     * Not required method!
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -38,7 +39,7 @@ class Etsy extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -46,18 +47,13 @@ class Etsy extends AbstractService
     }
 
     /**
-     * We need a separate request token parser only to verify the `oauth_callback_confirmed` parameter. For the actual
-     * parsing we can just use the default access token parser.
-     *
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseRequestTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
             throw new TokenResponseException('Error in retrieving token.');
@@ -67,30 +63,28 @@ class Etsy extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken( $data['oauth_token'] );
-        $token->setRequestTokenSecret( $data['oauth_token_secret'] );
-        $token->setAccessToken( $data['oauth_token'] );
-        $token->setAccessTokenSecret( $data['oauth_token_secret'] );
+        $token->setRequestToken($data['oauth_token']);
+        $token->setRequestTokenSecret($data['oauth_token_secret']);
+        $token->setAccessToken($data['oauth_token']);
+        $token->setAccessTokenSecret($data['oauth_token_secret']);
 
         $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset( $data['oauth_token'], $data['oauth_token_secret'] );
-        $token->setExtraParams( $data );
+        unset($data['oauth_token'], $data['oauth_token_secret']);
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Service/FitBit.php
+++ b/src/OAuth/OAuth1/Service/FitBit.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
@@ -15,13 +16,14 @@ class FitBit extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.fitbit.com/1/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getRequestTokenEndpoint()
     {
@@ -29,7 +31,7 @@ class FitBit extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -37,7 +39,7 @@ class FitBit extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -45,18 +47,13 @@ class FitBit extends AbstractService
     }
 
     /**
-     * We need a separate request token parser only to verify the `oauth_callback_confirmed` parameter. For the actual
-     * parsing we can just use the default access token parser.
-     *
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseRequestTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
             throw new TokenResponseException('Error in retrieving token.');
@@ -66,30 +63,28 @@ class FitBit extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken( $data['oauth_token'] );
-        $token->setRequestTokenSecret( $data['oauth_token_secret'] );
-        $token->setAccessToken( $data['oauth_token'] );
-        $token->setAccessTokenSecret( $data['oauth_token_secret'] );
+        $token->setRequestToken($data['oauth_token']);
+        $token->setRequestTokenSecret($data['oauth_token_secret']);
+        $token->setAccessToken($data['oauth_token']);
+        $token->setAccessTokenSecret($data['oauth_token_secret']);
 
         $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset( $data['oauth_token'], $data['oauth_token_secret'] );
-        $token->setExtraParams( $data );
+        unset($data['oauth_token'], $data['oauth_token_secret']);
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Service/ServiceInterface.php
+++ b/src/OAuth/OAuth1/Service/ServiceInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\Common\Consumer\Credentials;
@@ -16,20 +17,19 @@ use OAuth\OAuth1\Signature\SignatureInterface;
 interface ServiceInterface extends BaseServiceInterface
 {
     /**
-     * @param \OAuth\Common\Consumer\Credentials          $credentials
-     * @param \OAuth\Common\Http\Client\ClientInterface   $httpClient
-     * @param \OAuth\Common\Storage\TokenStorageInterface $storage
-     * @param \OAuth\OAuth1\Signature\SignatureInterface  $signature
-     * @param UriInterface|null                           $baseApiUri
-     * @abstract
+     * @param Credentials           $credentials
+     * @param ClientInterface       $httpClient
+     * @param TokenStorageInterface $storage
+     * @param SignatureInterface    $signature
+     * @param UriInterface|null     $baseApiUri
      */
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null);
 
     /**
-     * Retrieves and stores/returns the OAuth1 request token.
+     * Retrieves and stores/returns the OAuth1 request token obtained from the service.
      *
-     * @abstract
-     * @return TokenInterface         $token
+     * @return TokenInterface $token
+     *
      * @throws TokenResponseException
      */
     public function requestRequestToken();
@@ -37,17 +37,17 @@ interface ServiceInterface extends BaseServiceInterface
     /**
      * Retrieves and stores/returns the OAuth1 access token after a successful authorization.
      *
-     * @abstract
-     * @param  string                 $token       The request token from the callback.
-     * @param  string                 $verifier
-     * @param  string                 $tokenSecret
-     * @return TokenInterface         $token
+     * @param string $token       The request token from the callback.
+     * @param string $verifier
+     * @param string $tokenSecret
+     *
+     * @return TokenInterface $token
+     *
      * @throws TokenResponseException
      */
     public function requestAccessToken($token, $verifier, $tokenSecret);
 
     /**
-     * @abstract
      * @return UriInterface
      */
     public function getRequestTokenEndpoint();

--- a/src/OAuth/OAuth1/Service/Tumblr.php
+++ b/src/OAuth/OAuth1/Service/Tumblr.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
@@ -15,13 +16,14 @@ class Tumblr extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.tumblr.com/v2/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getRequestTokenEndpoint()
     {
@@ -29,17 +31,15 @@ class Tumblr extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
-        // @todo if the app will post tweets, authorize must be used instead.
-        // figure something out re: that but it's late and i don't want to now
         return new Uri('https://www.tumblr.com/oauth/authorize');
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -47,18 +47,13 @@ class Tumblr extends AbstractService
     }
 
     /**
-     * We need a separate request token parser only to verify the `oauth_callback_confirmed` parameter. For the actual
-     * parsing we can just use the default access token parser.
-     *
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseRequestTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
             throw new TokenResponseException('Error in retrieving token.');
@@ -68,30 +63,28 @@ class Tumblr extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken( $data['oauth_token'] );
-        $token->setRequestTokenSecret( $data['oauth_token_secret'] );
-        $token->setAccessToken( $data['oauth_token'] );
-        $token->setAccessTokenSecret( $data['oauth_token_secret'] );
+        $token->setRequestToken($data['oauth_token']);
+        $token->setRequestTokenSecret($data['oauth_token_secret']);
+        $token->setAccessToken($data['oauth_token']);
+        $token->setAccessTokenSecret($data['oauth_token_secret']);
 
         $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset( $data['oauth_token'], $data['oauth_token_secret'] );
-        $token->setExtraParams( $data );
+        unset($data['oauth_token'], $data['oauth_token_secret']);
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Service/Twitter.php
+++ b/src/OAuth/OAuth1/Service/Twitter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Service;
 
 use OAuth\OAuth1\Signature\SignatureInterface;
@@ -15,13 +16,14 @@ class Twitter extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, SignatureInterface $signature, UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.twitter.com/1.1/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getRequestTokenEndpoint()
     {
@@ -29,7 +31,7 @@ class Twitter extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -39,7 +41,7 @@ class Twitter extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -47,18 +49,13 @@ class Twitter extends AbstractService
     }
 
     /**
-     * We need a separate request token parser only to verify the `oauth_callback_confirmed` parameter. For the actual
-     * parsing we can just use the default access token parser.
-     *
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseRequestTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
             throw new TokenResponseException('Error in retrieving token.');
@@ -68,30 +65,28 @@ class Twitter extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth1\Token\StdOAuth1Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken( $data['oauth_token'] );
-        $token->setRequestTokenSecret( $data['oauth_token_secret'] );
-        $token->setAccessToken( $data['oauth_token'] );
-        $token->setAccessTokenSecret( $data['oauth_token_secret'] );
+        $token->setRequestToken($data['oauth_token']);
+        $token->setRequestTokenSecret($data['oauth_token_secret']);
+        $token->setAccessToken($data['oauth_token']);
+        $token->setAccessTokenSecret($data['oauth_token_secret']);
 
         $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset( $data['oauth_token'], $data['oauth_token_secret'] );
-        $token->setExtraParams( $data );
+        unset($data['oauth_token'], $data['oauth_token_secret']);
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Signature/Exception/UnsupportedHashAlgorithmException.php
+++ b/src/OAuth/OAuth1/Signature/Exception/UnsupportedHashAlgorithmException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Signature\Exception;
 
 use OAuth\Common\Exception\Exception;
@@ -8,5 +9,4 @@ use OAuth\Common\Exception\Exception;
  */
 class UnsupportedHashAlgorithmException extends Exception
 {
-
 }

--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Signature;
 
 use OAuth\Common\Consumer\Credentials;
@@ -8,7 +9,7 @@ use OAuth\OAuth1\Signature\Exception\UnsupportedHashAlgorithmException;
 class Signature implements SignatureInterface
 {
     /**
-     * @var \OAuth\Common\Consumer\Credentials
+     * @var Credentials
      */
     protected $credentials;
 
@@ -23,7 +24,7 @@ class Signature implements SignatureInterface
     protected $tokenSecret = null;
 
     /**
-     * @param \OAuth\Common\Consumer\Credentials $credentials
+     * @param Credentials $credentials
      */
     public function __construct(Credentials $credentials)
     {
@@ -47,9 +48,10 @@ class Signature implements SignatureInterface
     }
 
     /**
-     * @param  \OAuth\Common\Http\Uri\UriInterface $uri
-     * @param  array                               $params
-     * @param  string                              $method
+     * @param UriInterface $uri
+     * @param array        $params
+     * @param string       $method
+     *
      * @return string
      */
     public function getSignature(UriInterface $uri, array $params, $method = 'POST')
@@ -66,20 +68,21 @@ class Signature implements SignatureInterface
         $baseUri = $uri->getScheme() . '://' . $uri->getRawAuthority();
 
         if ('/' == $uri->getPath()) {
-            $baseUri.= $uri->hasExplicitTrailingHostSlash() ? '/' : '';
+            $baseUri .= $uri->hasExplicitTrailingHostSlash() ? '/' : '';
         } else {
             $baseUri .= $uri->getPath();
         }
 
         $baseString = strtoupper($method) . '&';
-        $baseString.= rawurlencode($baseUri) . '&';
-        $baseString.= rawurlencode($this->buildSignatureDataString($signatureData));
+        $baseString .= rawurlencode($baseUri) . '&';
+        $baseString .= rawurlencode($this->buildSignatureDataString($signatureData));
 
         return base64_encode($this->hash($baseString));
     }
 
     /**
-     * @param  array  $signatureData
+     * @param array $signatureData
+     *
      * @return string
      */
     protected function buildSignatureDataString(array $signatureData)
@@ -109,8 +112,10 @@ class Signature implements SignatureInterface
     }
 
     /**
-     * @param  string                            $data
+     * @param string $data
+     *
      * @return string
+     *
      * @throws UnsupportedHashAlgorithmException
      */
     protected function hash($data)
@@ -118,7 +123,6 @@ class Signature implements SignatureInterface
         switch (strtoupper($this->algorithm)) {
             case 'HMAC-SHA1':
                 return hash_hmac('sha1', $data, $this->getSigningKey(), true);
-
             default:
                 throw new UnsupportedHashAlgorithmException('Unsupported hashing algorithm (' . $this->algorithm . ') used.');
         }

--- a/src/OAuth/OAuth1/Signature/SignatureInterface.php
+++ b/src/OAuth/OAuth1/Signature/SignatureInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Signature;
 
 use OAuth\Common\Consumer\Credentials;
@@ -7,28 +8,26 @@ use OAuth\Common\Http\Uri\UriInterface;
 interface SignatureInterface
 {
     /**
-     * @param \OAuth\Common\Consumer\Credentials $credentials
-     * @abstract
+     * @param Credentials $credentials
      */
     public function __construct(Credentials $credentials);
 
     /**
      * @param string $algorithm
-     * @abstract
      */
     public function setHashingAlgorithm($algorithm);
 
     /**
      * @param string $token
-     * @abstract
      */
     public function setTokenSecret($token);
 
     /**
-     * @param \OAuth\Common\Http\Uri\UriInterface $uri
-     * @param array                               $params
-     * @param string                              $method
-     * @abstract
+     * @param UriInterface $uri
+     * @param array        $params
+     * @param string       $method
+     *
+     * @return string
      */
     public function getSignature(UriInterface $uri, array $params, $method = 'POST');
 }

--- a/src/OAuth/OAuth1/Token/StdOAuth1Token.php
+++ b/src/OAuth/OAuth1/Token/StdOAuth1Token.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Token;
 
 use OAuth\Common\Token\AbstractToken;

--- a/src/OAuth/OAuth1/Token/TokenInterface.php
+++ b/src/OAuth/OAuth1/Token/TokenInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth1\Token;
 
 use OAuth\Common\Token\TokenInterface as BaseTokenInterface;

--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\Common\Consumer\Credentials;
@@ -15,22 +16,22 @@ use OAuth\Common\Token\Exception\ExpiredTokenException;
 
 abstract class AbstractService extends BaseAbstractService implements ServiceInterface
 {
-
     /** @const OAUTH_VERSION */
     const OAUTH_VERSION = 2;
 
     /** @var array */
     protected $scopes;
 
-    /** @var \OAuth\Common\Http\Uri\UriInterface|null */
+    /** @var UriInterface|null */
     protected $baseApiUri;
 
     /**
-     * @param  \OAuth\Common\Consumer\Credentials          $credentials
-     * @param  \OAuth\Common\Http\Client\ClientInterface   $httpClient
-     * @param  \OAuth\Common\Storage\TokenStorageInterface $storage
-     * @param  array                                       $scopes
-     * @param  UriInterface|null                           $baseApiUri
+     * @param Credentials           $credentials
+     * @param ClientInterface       $httpClient
+     * @param TokenStorageInterface $storage
+     * @param array                 $scopes
+     * @param UriInterface|null     $baseApiUri
+     *
      * @throws InvalidScopeException
      */
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
@@ -38,8 +39,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         parent::__construct($credentials, $httpClient, $storage);
 
         foreach ($scopes as $scope) {
-            if ( !$this->isValidScope($scope) ) {
-                throw new InvalidScopeException('Scope ' . $scope . ' is not valid for service ' . get_class($this) );
+            if (!$this->isValidScope($scope)) {
+                throw new InvalidScopeException('Scope ' . $scope . ' is not valid for service ' . get_class($this));
             }
         }
 
@@ -49,12 +50,9 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     }
 
     /**
-     * Returns the url to redirect to for authorization purposes.
-     *
-     * @param  array  $additionalParameters
-     * @return string
+     * {@inheritdoc}
      */
-    public function getAuthorizationUri( array $additionalParameters = array() )
+    public function getAuthorizationUri(array $additionalParameters = array())
     {
         $parameters = array_merge($additionalParameters, array(
             'type'          => 'web_server',
@@ -75,11 +73,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     }
 
     /**
-     * Retrieves and stores the OAuth2 access token after a successful authorization.
-     *
-     * @param  string                 $code The access code from the callback.
-     * @return TokenInterface         $token
-     * @throws TokenResponseException
+     * {@inheritdoc}
      */
     public function requestAccessToken($code)
     {
@@ -92,8 +86,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         );
 
         $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), $bodyParams, $this->getExtraOAuthHeaders());
-        $token = $this->parseAccessTokenResponse( $responseBody );
-        $this->storage->storeAccessToken($this->service(), $token );
+        $token = $this->parseAccessTokenResponse($responseBody);
+        $this->storage->storeAccessToken($this->service(), $token);
 
         return $token;
     }
@@ -102,11 +96,13 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * Sends an authenticated API request to the path provided.
      * If the path provided is not an absolute URI, the base API Uri (must be passed into constructor) will be used.
      *
-     * @param $path string|UriInterface
-     * @param  string                $method       HTTP method
-     * @param  array                 $body         Request body if applicable.
-     * @param  array                 $extraHeaders Extra headers if applicable. These will override service-specific any defaults.
+     * @param string|UriInterface $path 
+     * @param string              $method       HTTP method
+     * @param array               $body         Request body if applicable.
+     * @param array               $extraHeaders Extra headers if applicable. These will override service-specific any defaults.
+     *
      * @return string
+     *
      * @throws ExpiredTokenException
      * @throws Exception
      */
@@ -115,34 +111,34 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $uri = $this->determineRequestUriFromPath($path, $this->baseApiUri);
         $token = $this->storage->retrieveAccessToken($this->service());
 
-        if( ( $token->getEndOfLife() !== TokenInterface::EOL_NEVER_EXPIRES ) &&
-            ( $token->getEndOfLife() !== TokenInterface::EOL_UNKNOWN ) &&
-            ( time() > $token->getEndOfLife() ) ) {
-
-            throw new ExpiredTokenException('Token expired on ' . date('m/d/Y', $token->getEndOfLife()) . ' at ' . date('h:i:s A', $token->getEndOfLife()) );
+        if ($token->getEndOfLife() !== TokenInterface::EOL_NEVER_EXPIRES
+            && $token->getEndOfLife() !== TokenInterface::EOL_UNKNOWN
+            && time() > $token->getEndOfLife()
+        ) {
+            throw new ExpiredTokenException('Token expired on ' . date('m/d/Y', $token->getEndOfLife()) . ' at ' . date('h:i:s A', $token->getEndOfLife()));
         }
 
         // add the token where it may be needed
-        if ( static::AUTHORIZATION_METHOD_HEADER_OAUTH === $this->getAuthorizationMethod() ) {
-            $extraHeaders = array_merge( array('Authorization' => 'OAuth ' . $token->getAccessToken()), $extraHeaders );
-        } elseif ( static::AUTHORIZATION_METHOD_QUERY_STRING === $this->getAuthorizationMethod() ) {
-            $uri->addToQuery( 'access_token', $token->getAccessToken() );
-        } elseif ( static::AUTHORIZATION_METHOD_QUERY_STRING_V2 === $this->getAuthorizationMethod() ) {
-            $uri->addToQuery( 'oauth2_access_token', $token->getAccessToken() );
-        } elseif ( static::AUTHORIZATION_METHOD_HEADER_BEARER === $this->getAuthorizationMethod() ) {
-            $extraHeaders = array_merge( array('Authorization' => 'Bearer ' . $token->getAccessToken()), $extraHeaders );
+        if (static::AUTHORIZATION_METHOD_HEADER_OAUTH === $this->getAuthorizationMethod()) {
+            $extraHeaders = array_merge(array('Authorization' => 'OAuth ' . $token->getAccessToken()), $extraHeaders);
+        } elseif (static::AUTHORIZATION_METHOD_QUERY_STRING === $this->getAuthorizationMethod()) {
+            $uri->addToQuery('access_token', $token->getAccessToken());
+        } elseif (static::AUTHORIZATION_METHOD_QUERY_STRING_V2 === $this->getAuthorizationMethod()) {
+            $uri->addToQuery('oauth2_access_token', $token->getAccessToken());
+        } elseif (static::AUTHORIZATION_METHOD_HEADER_BEARER === $this->getAuthorizationMethod()) {
+            $extraHeaders = array_merge(array('Authorization' => 'Bearer ' . $token->getAccessToken()), $extraHeaders);
         }
 
-        $extraHeaders = array_merge( $this->getExtraApiHeaders(), $extraHeaders );
+        $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);
 
         return $this->httpClient->retrieveResponse($uri, $body, $extraHeaders, $method);
     }
 
     /**
-    * Accessor to the storage adapter to be able to retrieve tokens
-    *
-    * @return OAuth\Common\Storage\TokenStorageInterface
-    */
+     * Accessor to the storage adapter to be able to retrieve tokens
+     *
+     * @return TokenStorageInterface
+     */
     public function getStorage()
     {
         return $this->storage;
@@ -151,15 +147,17 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /**
      * Refreshes an OAuth2 access token.
      *
-     * @param  \OAuth\Common\Token\TokenInterface                           $token
-     * @return \OAuth\Common\Token\TokenInterface                           $token
-     * @throws \OAuth\OAuth2\Service\Exception\MissingRefreshTokenException
+     * @param TokenInterface $token
+     *
+     * @return TokenInterface $token
+     *
+     * @throws MissingRefreshTokenException
      */
     public function refreshAccessToken(TokenInterface $token)
     {
         $refreshToken = $token->getRefreshToken();
 
-        if ( empty( $refreshToken ) ) {
+        if (empty($refreshToken)) {
             throw new MissingRefreshTokenException();
         }
 
@@ -181,14 +179,15 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /**
      * Return whether or not the passed scope value is valid.
      *
-     * @param $scope
+     * @param string $scope
+     *
      * @return bool
      */
     public function isValidScope($scope)
     {
         $reflectionClass = new \ReflectionClass(get_class($this));
 
-        return in_array( $scope, $reflectionClass->getConstants() );
+        return in_array($scope, $reflectionClass->getConstants());
     }
 
     /**
@@ -215,8 +214,12 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * Parses the access token response and returns a TokenInterface.
      *
      * @abstract
-     * @return \OAuth\Common\Token\TokenInterface
-     * @param  string                             $responseBody
+     *
+     * @param string $responseBody
+     *
+     * @return TokenInterface
+     *
+     * @throws TokenResponseException
      */
     abstract protected function parseAccessTokenResponse($responseBody);
 

--- a/src/OAuth/OAuth2/Service/Amazon.php
+++ b/src/OAuth/OAuth2/Service/Amazon.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -21,20 +22,20 @@ class Amazon extends AbstractService
      * Defined scopes
      * @link https://images-na.ssl-images-amazon.com/images/G/01/lwa/dev/docs/website-developer-guide._TTH_.pdf
      */
-
-    const SCOPE_PROFILE          = 'profile';
-    const SCOPE_POSTAL_CODE            = 'postal_code';
+    const SCOPE_PROFILE     = 'profile';
+    const SCOPE_POSTAL_CODE = 'postal_code';
 
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.amazon.com/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -42,7 +43,7 @@ class Amazon extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -50,10 +51,7 @@ class Amazon extends AbstractService
     }
 
     /**
-     * Returns a class constant from ServiceInterface defining the authorization method used for the API
-     * Header is the sane default.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     protected function getAuthorizationMethod()
     {
@@ -61,35 +59,33 @@ class Amazon extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error_description'] ) ) {
+        } elseif (isset($data['error_description'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error_description'] . '"');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifeTime($data['expires_in']);
 
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifeTime( $data['expires_in'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+        unset($data['expires_in']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Box.php
+++ b/src/OAuth/OAuth2/Service/Box.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -20,13 +21,14 @@ class Box extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.box.com/2.0/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -34,7 +36,7 @@ class Box extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -42,10 +44,7 @@ class Box extends AbstractService
     }
 
     /**
-     * Returns a class constant from ServiceInterface defining the authorization method used for the API
-     * Header is the sane default.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     protected function getAuthorizationMethod()
     {
@@ -53,33 +52,31 @@ class Box extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifeTime($data['expires_in']);
 
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifeTime( $data['expires_in'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+        unset($data['expires_in']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Dropbox.php
+++ b/src/OAuth/OAuth2/Service/Dropbox.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -21,18 +22,16 @@ class Dropbox extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.dropbox.com/1/');
         }
     }
 
     /**
-     * Returns the url to redirect to for authorization purposes.
-     *
-     * @param  array  $additionalParameters
-     * @return string
+     * {@inheritdoc}
      */
-    public function getAuthorizationUri( array $additionalParameters = array() )
+    public function getAuthorizationUri(array $additionalParameters = array())
     {
         $parameters = array_merge($additionalParameters, array(
             'client_id'     => $this->credentials->getConsumerId(),
@@ -52,7 +51,7 @@ class Dropbox extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -60,7 +59,7 @@ class Dropbox extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -68,10 +67,7 @@ class Dropbox extends AbstractService
     }
 
     /**
-     * Returns a class constant from ServiceInterface defining the authorization method used for the API
-     * Header is the sane default.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     protected function getAuthorizationMethod()
     {
@@ -79,31 +75,29 @@ class Dropbox extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
 
-        $token->setAccessToken( $data['access_token'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Exception/InvalidScopeException.php
+++ b/src/OAuth/OAuth2/Service/Exception/InvalidScopeException.php
@@ -1,9 +1,12 @@
 <?php
+
 /**
  * @author David Desberg <david@daviddesberg.com>
  * Released under the MIT license.
  */
+
 namespace OAuth\OAuth2\Service\Exception;
+
 use OAuth\Common\Exception\Exception;
 
 /**
@@ -11,5 +14,4 @@ use OAuth\Common\Exception\Exception;
  */
 class InvalidScopeException extends Exception
 {
-
 }

--- a/src/OAuth/OAuth2/Service/Exception/MissingRefreshTokenException.php
+++ b/src/OAuth/OAuth2/Service/Exception/MissingRefreshTokenException.php
@@ -1,9 +1,12 @@
 <?php
+
 /**
  * @author David Desberg <david@daviddesberg.com>
  * Released under the MIT license.
  */
+
 namespace OAuth\OAuth2\Service\Exception;
+
 use OAuth\Common\Exception\Exception;
 
 /**
@@ -11,5 +14,4 @@ use OAuth\Common\Exception\Exception;
  */
 class MissingRefreshTokenException extends Exception
 {
-
 }

--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -14,13 +15,14 @@ class Facebook extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://graph.facebook.com/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -28,7 +30,7 @@ class Facebook extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -36,34 +38,32 @@ class Facebook extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
         // Facebook gives us a query string ... Oh wait. JSON is too simple, understand ?
         parse_str($responseBody, $data);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifeTime($data['expires']);
 
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifeTime( $data['expires'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        unset( $data['expires'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+        unset($data['expires']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -16,13 +17,14 @@ class Foursquare extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.foursquare.com/v2/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -30,7 +32,7 @@ class Foursquare extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -38,31 +40,32 @@ class Foursquare extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
-
-        $token->setAccessToken( $data['access_token'] );
+        $token->setAccessToken($data['access_token']);
         // Foursquare tokens evidently never expire...
         $token->setEndOfLife(StdOAuth2Token::EOL_NEVER_EXPIRES);
-        unset( $data['access_token'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $uri = new Uri($this->baseApiUri . $path);
@@ -70,5 +73,4 @@ class Foursquare extends AbstractService
 
         return parent::request($uri, $method, $body, $extraHeaders);
     }
-
 }

--- a/src/OAuth/OAuth2/Service/GitHub.php
+++ b/src/OAuth/OAuth2/Service/GitHub.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -23,13 +24,14 @@ class GitHub extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.github.com/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -37,7 +39,7 @@ class GitHub extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -45,27 +47,33 @@ class GitHub extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
+     */
+    protected function getAuthorizationMethod()
+    {
+        return static::AUTHORIZATION_METHOD_QUERY_STRING;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
-
-        $token->setAccessToken( $data['access_token'] );
+        $token->setAccessToken($data['access_token']);
         // Github tokens evidently never expire...
         $token->setEndOfLife(StdOAuth2Token::EOL_NEVER_EXPIRES);
-        unset( $data['access_token'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }
@@ -88,13 +96,5 @@ class GitHub extends AbstractService
     protected function getExtraApiHeaders()
     {
         return array('Accept' => 'application/vnd.github.beta+json');
-    }
-
-    /**
-     * @return int
-     */
-    protected function getAuthorizationMethod()
-    {
-        return static::AUTHORIZATION_METHOD_QUERY_STRING;
     }
 }

--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -43,7 +44,7 @@ class Google extends AbstractService
     const SCOPE_YOUTUBE = 'https://gdata.youtube.com';
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -51,7 +52,7 @@ class Google extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -59,33 +60,31 @@ class Google extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifetime( $data['expires_in'] );
+        $token->setAccessToken($data['access_token']);
+        $token->setLifetime($data['expires_in']);
 
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
+        unset($data['access_token']);
+        unset($data['expires_in']);
 
-        $token->setExtraParams( $data );
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Instagram.php
+++ b/src/OAuth/OAuth2/Service/Instagram.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -23,13 +24,14 @@ class Instagram extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.instagram.com/v1/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -37,7 +39,7 @@ class Instagram extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -45,10 +47,7 @@ class Instagram extends AbstractService
     }
 
     /**
-     * Returns a class constant from ServiceInterface defining the authorization method used for the API
-     * Header is the sane default.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     protected function getAuthorizationMethod()
     {
@@ -56,27 +55,25 @@ class Instagram extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
-
-        $token->setAccessToken( $data['access_token'] );
+        $token->setAccessToken($data['access_token']);
         // Instagram tokens evidently never expire...
         $token->setEndOfLife(StdOAuth2Token::EOL_NEVER_EXPIRES);
-        unset( $data['access_token'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Linkedin.php
+++ b/src/OAuth/OAuth2/Service/Linkedin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -33,13 +34,14 @@ class Linkedin extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.linkedin.com/v1/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -47,7 +49,7 @@ class Linkedin extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -55,10 +57,7 @@ class Linkedin extends AbstractService
     }
 
     /**
-     * Returns a class constant from ServiceInterface defining the authorization method used for the API
-     * Header is the sane default.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     protected function getAuthorizationMethod()
     {
@@ -66,33 +65,31 @@ class Linkedin extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifeTime($data['expires_in']);
 
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifeTime( $data['expires_in'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+        unset($data['expires_in']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Microsoft.php
+++ b/src/OAuth/OAuth2/Service/Microsoft.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -38,13 +39,14 @@ class Microsoft extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://apis.live.net/v5.0/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -52,7 +54,7 @@ class Microsoft extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -60,42 +62,40 @@ class Microsoft extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        $data = json_decode( $responseBody, true );
-
-        if ( null === $data || !is_array($data) ) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth2Token();
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifetime( $data['expires_in'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
-            unset($data['refresh_token']);
-        }
-
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
-
-        $token->setExtraParams( $data );
-
-        return $token;
-    }
-
-    /**
-     * @return int
+     * {@inheritdoc}
      */
     public function getAuthorizationMethod()
     {
         return static::AUTHORIZATION_METHOD_QUERY_STRING;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseAccessTokenResponse($responseBody)
+    {
+        $data = json_decode($responseBody, true);
+
+        if (null === $data || !is_array($data)) {
+            throw new TokenResponseException('Unable to parse response.');
+        } elseif (isset($data['error'])) {
+            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
+        }
+
+        $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifetime($data['expires_in']);
+
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
+            unset($data['refresh_token']);
+        }
+
+        unset($data['access_token']);
+        unset($data['expires_in']);
+
+        $token->setExtraParams($data);
+
+        return $token;
     }
 }

--- a/src/OAuth/OAuth2/Service/ServiceInterface.php
+++ b/src/OAuth/OAuth2/Service/ServiceInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\Common\Consumer\Credentials;
@@ -23,21 +24,21 @@ interface ServiceInterface extends BaseServiceInterface
     const AUTHORIZATION_METHOD_QUERY_STRING_V2 = 3;
 
     /**
-     * @param \OAuth\Common\Consumer\Credentials          $credentials
-     * @param \OAuth\Common\Http\Client\ClientInterface   $httpClient
-     * @param \OAuth\Common\Storage\TokenStorageInterface $storage
-     * @param array                                       $scopes
-     * @param UriInterface|null                           $baseApiUri
-     * @abstract
+     * @param Credentials           $credentials
+     * @param ClientInterface       $httpClient
+     * @param TokenStorageInterface $storage
+     * @param array                 $scopes
+     * @param UriInterface|null     $baseApiUri
      */
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null);
 
     /**
      * Retrieves and stores/returns the OAuth2 access token after a successful authorization.
      *
-     * @abstract
-     * @param  string                 $code The access code from the callback.
-     * @return TokenInterface         $token
+     * @param string $code The access code from the callback.
+     *
+     * @return TokenInterface $token
+     *
      * @throws TokenResponseException
      */
     public function requestAccessToken($code);

--- a/src/OAuth/OAuth2/Service/SoundCloud.php
+++ b/src/OAuth/OAuth2/Service/SoundCloud.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -14,13 +15,14 @@ class SoundCloud extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.soundcloud.com/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -28,7 +30,7 @@ class SoundCloud extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -36,36 +38,34 @@ class SoundCloud extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        $data = json_decode( $responseBody, true );
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
-        $token->setAccessToken( $data['access_token'] );
+        $token->setAccessToken($data['access_token']);
 
-        if ( isset( $data['expires_in'] ) ) {
-            $token->setLifetime( $data['expires_in'] );
-            unset( $data['expires_in'] );
+        if (isset($data['expires_in'])) {
+            $token->setLifetime($data['expires_in']);
+            unset($data['expires_in']);
         }
 
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
+        unset($data['access_token']);
 
-        $token->setExtraParams( $data );
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Vkontakte.php
+++ b/src/OAuth/OAuth2/Service/Vkontakte.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -14,13 +15,14 @@ class Vkontakte extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.vk.com/method/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -28,7 +30,7 @@ class Vkontakte extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -36,33 +38,31 @@ class Vkontakte extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
+     * {@inheritdoc}
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-    $data = json_decode($responseBody, true);
+        $data = json_decode($responseBody, true);
 
-        if ( null === $data || !is_array($data) ) {
+        if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
+        } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
 
         $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifeTime($data['expires_in']);
 
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifeTime( $data['expires_in'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
             unset($data['refresh_token']);
         }
 
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
-        $token->setExtraParams( $data );
+        unset($data['access_token']);
+        unset($data['expires_in']);
+
+        $token->setExtraParams($data);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Yammer.php
+++ b/src/OAuth/OAuth2/Service/Yammer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Service;
 
 use OAuth\OAuth2\Token\StdOAuth2Token;
@@ -14,13 +15,14 @@ class Yammer extends AbstractService
     public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage, $scopes = array(), UriInterface $baseApiUri = null)
     {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://www.yammer.com/api/v1/');
         }
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAuthorizationEndpoint()
     {
@@ -28,7 +30,7 @@ class Yammer extends AbstractService
     }
 
     /**
-     * @return \OAuth\Common\Http\Uri\UriInterface
+     * {@inheritdoc}
      */
     public function getAccessTokenEndpoint()
     {
@@ -36,42 +38,40 @@ class Yammer extends AbstractService
     }
 
     /**
-     * @param  string                                                                $responseBody
-     * @return \OAuth\Common\Token\TokenInterface|\OAuth\OAuth2\Token\StdOAuth2Token
-     * @throws \OAuth\Common\Http\Exception\TokenResponseException
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        $data = json_decode( $responseBody, true );
-
-        if ( null === $data || !is_array($data) ) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif ( isset($data['error'] ) ) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth2Token();
-        $token->setAccessToken( $data['access_token'] );
-        $token->setLifetime( $data['expires_in'] );
-
-        if ( isset($data['refresh_token'] ) ) {
-            $token->setRefreshToken( $data['refresh_token'] );
-            unset($data['refresh_token']);
-        }
-
-        unset( $data['access_token'] );
-        unset( $data['expires_in'] );
-
-        $token->setExtraParams( $data );
-
-        return $token;
-    }
-
-    /**
-     * @return int
+     * {@inheritdoc}
      */
     public function getAuthorizationMethod()
     {
         return static::AUTHORIZATION_METHOD_HEADER_BEARER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseAccessTokenResponse($responseBody)
+    {
+        $data = json_decode($responseBody, true);
+
+        if (null === $data || !is_array($data)) {
+            throw new TokenResponseException('Unable to parse response.');
+        } elseif (isset($data['error'])) {
+            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
+        }
+
+        $token = new StdOAuth2Token();
+        $token->setAccessToken($data['access_token']);
+        $token->setLifetime($data['expires_in']);
+
+        if (isset($data['refresh_token'])) {
+            $token->setRefreshToken($data['refresh_token']);
+            unset($data['refresh_token']);
+        }
+
+        unset($data['access_token']);
+        unset($data['expires_in']);
+
+        $token->setExtraParams($data);
+
+        return $token;
     }
 }

--- a/src/OAuth/OAuth2/Token/StdOAuth2Token.php
+++ b/src/OAuth/OAuth2/Token/StdOAuth2Token.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Token;
 
 use OAuth\Common\Token\AbstractToken;

--- a/src/OAuth/OAuth2/Token/TokenInterface.php
+++ b/src/OAuth/OAuth2/Token/TokenInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\OAuth2\Token;
 
 use OAuth\Common\Token\TokenInterface as BaseTokenInterface;

--- a/src/OAuth/ServiceFactory.php
+++ b/src/OAuth/ServiceFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * OAuth service factory.
  *
@@ -9,17 +10,25 @@
  * @copyright  Copyright (c) 2013 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
 namespace OAuth;
+
 use OAuth\Common\Service\ServiceInterface;
+use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Http\Client\StreamClient;
+use OAuth\Common\Exception\Exception;
+use OAuth\OAuth1\Signature\Signature;
 
 class ServiceFactory
 {
-    /** @var Common\Http\Client\ClientInterface */
+    /** @var ClientInterface */
     private $httpClient;
 
     /**
-     * @param  Common\Http\Client\ClientInterface $httpClient
+     * @param ClientInterface $httpClient
+     *
      * @return ServiceFactory
      */
     public function setHttpClient(ClientInterface $httpClient)
@@ -30,18 +39,20 @@ class ServiceFactory
     }
 
     /**
-     * @param $serviceName string name of service to create
-     * @param  Common\Consumer\Credentials          $credentials
-     * @param  Common\Storage\TokenStorageInterface $storage
-     * @param  array|null                           $scopes      If creating an oauth2 service, array of scopes
+     * @param string                $serviceName Name of service to create
+     * @param Credentials           $credentials
+     * @param TokenStorageInterface $storage
+     * @param array|null            $scopes      If creating an oauth2 service, array of scopes
+     *
      * @return ServiceInterface
-     * @throws Common\Exception\Exception
+     *
+     * @throws Exception
      */
-    public function createService($serviceName, Common\Consumer\Credentials $credentials, Common\Storage\TokenStorageInterface $storage, $scopes = array())
+    public function createService($serviceName, Credentials $credentials, TokenStorageInterface $storage, $scopes = array())
     {
         if (!$this->httpClient) {
             // for backwards compatibility.
-            $this->httpClient = new \OAuth\Common\Http\Client\StreamClient();
+            $this->httpClient = new StreamClient();
         }
 
         $serviceName = ucfirst($serviceName);
@@ -49,7 +60,7 @@ class ServiceFactory
         $v1ClassName = "\\OAuth\\OAuth1\\Service\\$serviceName";
 
         // if an oauth2 version exists, prefer it
-        if ( class_exists($v2ClassName) ) {
+        if (class_exists($v2ClassName)) {
             // resolve scopes
             $resolvedScopes = array();
             $reflClass = new \ReflectionClass($v2ClassName);
@@ -58,7 +69,7 @@ class ServiceFactory
             foreach ($scopes as $scope) {
                 $key = strtoupper('SCOPE_' . $scope);
                 // try to find a class constant with this name
-                if ( array_key_exists( $key, $constants ) ) {
+                if (array_key_exists($key, $constants)) {
                     $resolvedScopes[] = $constants[$key];
                 } else {
                     $resolvedScopes[] = $scope;
@@ -68,11 +79,11 @@ class ServiceFactory
             return new $v2ClassName($credentials, $this->httpClient, $storage, $resolvedScopes);
         }
 
-        if ( class_exists($v1ClassName) ) {
+        if (class_exists($v1ClassName)) {
             if (!empty($scopes)) {
-                throw new Common\Exception\Exception('Scopes passed to ServiceFactory::createService but an OAuth1 service was requested.');
+                throw new Exception('Scopes passed to ServiceFactory::createService but an OAuth1 service was requested.');
             }
-            $signature = new OAuth1\Signature\Signature($credentials);
+            $signature = new Signature($credentials);
 
             return new $v1ClassName($credentials, $this->httpClient, $storage, $signature);
         }

--- a/src/OAuth/bootstrap.php
+++ b/src/OAuth/bootstrap.php
@@ -1,11 +1,13 @@
 <?php
+
 /*
  * Bootstrap the library.
  */
+
 namespace OAuth;
 
 require_once __DIR__ . '/Common/AutoLoader.php';
 
-$autoloader = new \OAuth\Common\AutoLoader(__NAMESPACE__, dirname(__DIR__));
+$autoloader = new Common\AutoLoader(__NAMESPACE__, dirname(__DIR__));
 
 $autoloader->register();

--- a/tests/OAuth/Unit/Common/Consumer/CredentialsTest.php
+++ b/tests/OAuth/Unit/Common/Consumer/CredentialsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace OAuth\Unit\Common\Consumer;
 
 use OAuth\Common\Consumer\Credentials;
@@ -11,8 +12,8 @@ class CredentialsTest extends \PHPUnit_Framework_TestCase
     public function testGetters()
     {
         $a = new Credentials('a', 'b', 'c');
-        $this->assertSame('a', $a->getConsumerId() );
-        $this->assertSame('b', $a->getConsumerSecret() );
-        $this->assertSame('c', $a->getCallbackUrl() );
+        $this->assertSame('a', $a->getConsumerId());
+        $this->assertSame('b', $a->getConsumerSecret());
+        $this->assertSame('c', $a->getCallbackUrl());
     }
 }

--- a/tests/OAuth/Unit/Common/Http/HttpClientsTest.php
+++ b/tests/OAuth/Unit/Common/Http/HttpClientsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -7,10 +8,13 @@
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace OAuth\Unit\Common\Http;
+
 use OAuth\Common\Http\Uri\Uri;
+use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Http\Client;
 
-class HttpClientsTest extends PHPUnit_Framework_TestCase
+class HttpClientsTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var object|\OAuth\Common\Http\Client\ClientInterface[]
@@ -44,13 +48,14 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
         $testUri = new Uri('http://httpbin.org/get');
 
         $me = $this;
-        $headerCb = function($response) use ($me) {
+        $headerCb = function ($response) use ($me) {
             $data = json_decode($response, true);
             $me->assertEquals('extraheadertest', $data['headers']['Testingheader']);
         };
 
         $this->__doTestRetrieveResponse($testUri, array(), array('Testingheader' => 'extraheadertest'), 'GET', $headerCb);
     }
+
     /**
      * Tests that we get an exception for a >= 400 status code
      */
@@ -60,9 +65,8 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
         $testUri = new Uri('http://httpbin.org/delete');
         foreach ($this->clients as $client) {
             $this->setExpectedException('OAuth\Common\Http\Exception\TokenResponseException');
-            $client->retrieveResponse($testUri, array('blah' => 'blih') );
+            $client->retrieveResponse($testUri, array('blah' => 'blih'));
         }
-
     }
 
     /**
@@ -73,12 +77,12 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
         $testUri = new Uri('http://httpbin.org/delete');
 
         $me = $this;
-        $deleteTestCb = function($response) use ($me) {
+        $deleteTestCb = function ($response) use ($me) {
             $data = json_decode($response, true);
-            $me->assertEquals( '', $data['data'] );
+            $me->assertEquals('', $data['data']);
         };
 
-        $this->__doTestRetrieveResponse($testUri, array(), array(), 'DELETE', $deleteTestCb );
+        $this->__doTestRetrieveResponse($testUri, array(), array(), 'DELETE', $deleteTestCb);
     }
 
     /**
@@ -89,13 +93,13 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
         $testUri = new Uri('http://httpbin.org/put');
 
         $me = $this;
-        $putTestCb = function($response) use ($me) {
+        $putTestCb = function ($response) use ($me) {
             // verify the put response
             $data = json_decode($response, true);
-            $me->assertEquals( json_encode( array('testKey' => 'testValue') ), $data['data'] );
+            $me->assertEquals(json_encode(array('testKey' => 'testValue')), $data['data']);
         };
 
-        $this->__doTestRetrieveResponse($testUri, json_encode( array('testKey' => 'testValue') ), array('Content-type' => 'application/json'), 'PUT', $putTestCb );
+        $this->__doTestRetrieveResponse($testUri, json_encode(array('testKey' => 'testValue')), array('Content-type' => 'application/json'), 'PUT', $putTestCb);
     }
 
     /**
@@ -107,15 +111,15 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
         $testUri = new Uri('http://httpbin.org/post');
 
         $me = $this;
-        $postTestCb = function($response) use ($me) {
+        $postTestCb = function ($response) use ($me) {
             // verify the post response
             $data = json_decode($response, true);
             // note that we check this because the retrieveResponse wrapper function automatically adds a content-type
             // if there isn't one and it
-            $me->assertEquals( 'testValue', $data['form']['testKey'] );
+            $me->assertEquals('testValue', $data['form']['testKey']);
         };
 
-        $this->__doTestRetrieveResponse($testUri, array('testKey' => 'testValue'), array(), 'POST', $postTestCb );
+        $this->__doTestRetrieveResponse($testUri, array('testKey' => 'testValue'), array(), 'POST', $postTestCb);
     }
 
     /**
@@ -127,7 +131,7 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
 
         foreach ($this->clients as $client) {
             $this->setExpectedException('InvalidArgumentException');
-            $client->retrieveResponse($testUri, array('blah' => 'blih'), array(), 'GET' );
+            $client->retrieveResponse($testUri, array('blah' => 'blih'), array(), 'GET');
         }
     }
 
@@ -140,25 +144,24 @@ class HttpClientsTest extends PHPUnit_Framework_TestCase
         $testUri = new Uri('http://httpbin.org/get?testKey=testValue');
 
         $me = $this;
-        $getTestCb = function($response) use ($me) {
+        $getTestCb = function ($response) use ($me) {
             $data = json_decode($response, true);
-            $me->assertEquals( 'testValue', $data['args']['testKey'] );
+            $me->assertEquals('testValue', $data['args']['testKey']);
         };
 
         $this->__doTestRetrieveResponse($testUri, array(), array(), 'GET', $getTestCb);
-
     }
 
     /**
      * Test on all HTTP clients.
      *
-     * @param OAuth\Common\Http\Uri\UriInterface $uri
-     * @param array                              $param
-     * @param array                              $header
-     * @param $method
-     * @param $responseCallback
+     * @param UriInterface $uri
+     * @param array        $param
+     * @param array        $header
+     * @param string       $method
+     * @param \Closure     $responseCallback
      */
-    protected function __doTestRetrieveResponse(\OAuth\Common\Http\Uri\UriInterface $uri, $param, array $header, $method, $responseCallback)
+    protected function __doTestRetrieveResponse(UriInterface $uri, $param, array $header, $method, $responseCallback)
     {
         foreach ($this->clients as $client) {
             $response = $client->retrieveResponse($uri, $param, $header, $method);

--- a/tests/OAuth/Unit/Common/Http/UriTest.php
+++ b/tests/OAuth/Unit/Common/Http/UriTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -8,9 +9,11 @@
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace OAuth\Unit\Common\Http;
+
 use OAuth\Common\Http\Uri\UriFactory;
 
-class UriTest extends PHPUnit_Framework_TestCase
+class UriTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var UriFactory
@@ -34,19 +37,18 @@ class UriTest extends PHPUnit_Framework_TestCase
     {
         $absoluteUri = 'https://joe:bob@example.com:6912/relative/path?user=jon&password=secret#div';
         $uri = $this->uriFactory->createFromAbsolute($absoluteUri);
-        $this->assertEquals( $absoluteUri, $uri->getAbsoluteUri() );
-        $this->assertEquals( 6912, $uri->getPort() );
-        $this->assertEquals( 'example.com', $uri->getHost() );
-        $this->assertEquals( 'https', $uri->getScheme() );
-        $this->assertEquals( '/relative/path', $uri->getPath() );
-        $this->assertEquals( 'joe:bob', $uri->getRawUserInfo() );
-        $this->assertEquals( 'div', $uri->getFragment() );
-        $this->assertEquals( 'joe:********', $uri->getUserInfo() );
-        $this->assertEquals( 'joe:********@example.com:6912', $uri->getAuthority() );
-        $this->assertEquals( 'joe:bob@example.com:6912', $uri->getRawAuthority() );
-
-        $this->assertEquals( 'https://joe:********@example.com:6912/relative/path?user=jon&password=secret#div', (string) $uri );
-        $this->assertEquals( '/relative/path', $uri->getRelativeUri() );
+        $this->assertEquals($absoluteUri, $uri->getAbsoluteUri());
+        $this->assertEquals(6912, $uri->getPort());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('/relative/path', $uri->getPath());
+        $this->assertEquals('joe:bob', $uri->getRawUserInfo());
+        $this->assertEquals('div', $uri->getFragment());
+        $this->assertEquals('joe:********', $uri->getUserInfo());
+        $this->assertEquals('joe:********@example.com:6912', $uri->getAuthority());
+        $this->assertEquals('joe:bob@example.com:6912', $uri->getRawAuthority());
+        $this->assertEquals('https://joe:********@example.com:6912/relative/path?user=jon&password=secret#div', (string) $uri);
+        $this->assertEquals('/relative/path', $uri->getRelativeUri());
     }
 
     /**
@@ -56,16 +58,16 @@ class UriTest extends PHPUnit_Framework_TestCase
     {
         $absoluteUri = 'https://joe:bob@example.com:6912/relative/path?user=jon&password=secret#div';
         $uri = $this->uriFactory->createFromParts('https', 'joe:bob', 'example.com', 6912, '/relative/path', 'user=jon&password=secret', 'div');
-        $this->assertEquals( $absoluteUri, $uri->getAbsoluteUri() );
-        $this->assertEquals( 6912, $uri->getPort() );
-        $this->assertEquals( 'example.com', $uri->getHost() );
-        $this->assertEquals( 'https', $uri->getScheme() );
-        $this->assertEquals( '/relative/path', $uri->getPath() );
-        $this->assertEquals( 'joe:bob', $uri->getRawUserInfo() );
-        $this->assertEquals( 'div', $uri->getFragment() );
-        $this->assertEquals( 'joe:********', $uri->getUserInfo() );
-        $this->assertEquals( 'joe:********@example.com:6912', $uri->getAuthority() );
-        $this->assertEquals( 'joe:bob@example.com:6912', $uri->getRawAuthority() );
+        $this->assertEquals($absoluteUri, $uri->getAbsoluteUri());
+        $this->assertEquals(6912, $uri->getPort());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('/relative/path', $uri->getPath());
+        $this->assertEquals('joe:bob', $uri->getRawUserInfo());
+        $this->assertEquals('div', $uri->getFragment());
+        $this->assertEquals('joe:********', $uri->getUserInfo());
+        $this->assertEquals('joe:********@example.com:6912', $uri->getAuthority());
+        $this->assertEquals('joe:bob@example.com:6912', $uri->getRawAuthority());
     }
 
     /**
@@ -77,13 +79,13 @@ class UriTest extends PHPUnit_Framework_TestCase
         $uri = $this->uriFactory->createFromAbsolute($absoluteUri);
 
         $uri->setPort(443);
-        $this->assertEquals( str_replace(':6912', '', $absoluteUri ), $uri->getAbsoluteUri() );
+        $this->assertEquals(str_replace(':6912', '', $absoluteUri), $uri->getAbsoluteUri());
 
         $uri->setPort(6912);
-        $this->assertEquals( $absoluteUri, $uri->getAbsoluteUri() );
+        $this->assertEquals($absoluteUri, $uri->getAbsoluteUri());
 
         $uri->setHost('github.com');
-        $this->assertEquals( str_replace('example.com', 'github.com', $absoluteUri ), $uri->getAbsoluteUri() );
+        $this->assertEquals(str_replace('example.com', 'github.com', $absoluteUri), $uri->getAbsoluteUri());
     }
 
     public function testExceptionOnBadUri()
@@ -106,12 +108,12 @@ class UriTest extends PHPUnit_Framework_TestCase
 
         $uri = $this->uriFactory->createFromSuperGlobalArray($serverArray);
 
-        $this->assertEquals( $uri->getAbsoluteUri(), 'http://example.com/some/relative/path?test=param' );
-        $this->assertEquals( $uri->getHost(), 'example.com' );
-        $this->assertEquals( $uri->getPort(), 80 );
-        $this->assertEquals( $uri->getScheme(), 'http' );
-        $this->assertEquals( $uri->getPath(), '/some/relative/path' );
-        $this->assertEquals( $uri->getFragment(), '' );
+        $this->assertEquals($uri->getAbsoluteUri(), 'http://example.com/some/relative/path?test=param');
+        $this->assertEquals($uri->getHost(), 'example.com');
+        $this->assertEquals($uri->getPort(), 80);
+        $this->assertEquals($uri->getScheme(), 'http');
+        $this->assertEquals($uri->getPath(), '/some/relative/path');
+        $this->assertEquals($uri->getFragment(), '');
     }
 
 
@@ -130,11 +132,11 @@ class UriTest extends PHPUnit_Framework_TestCase
 
         $uri = $this->uriFactory->createFromSuperGlobalArray($serverArray);
 
-        $this->assertEquals( $uri->getAbsoluteUri(), 'http://example.com:7000/some/relative/path?test=param' );
-        $this->assertEquals( $uri->getHost(), 'example.com' );
-        $this->assertEquals( $uri->getPort(), 7000 );
-        $this->assertEquals( $uri->getScheme(), 'http' );
-        $this->assertEquals( $uri->getPath(), '/some/relative/path' );
-        $this->assertEquals( $uri->getFragment(), '' );
+        $this->assertEquals($uri->getAbsoluteUri(), 'http://example.com:7000/some/relative/path?test=param');
+        $this->assertEquals($uri->getHost(), 'example.com');
+        $this->assertEquals($uri->getPort(), 7000);
+        $this->assertEquals($uri->getScheme(), 'http');
+        $this->assertEquals($uri->getPath(), '/some/relative/path');
+        $this->assertEquals($uri->getFragment(), '');
     }
 }

--- a/tests/OAuth/Unit/Common/Storage/MemoryTest.php
+++ b/tests/OAuth/Unit/Common/Storage/MemoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -7,12 +8,13 @@
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace OAuth\Unit\Common\Storage;
+
 use OAuth\Common\Storage\Memory;
 use OAuth\Unit\Common\Storage\StorageTest;
 
 class MemoryTest extends StorageTest
 {
-
     public function setUp()
     {
         // set it
@@ -24,5 +26,4 @@ class MemoryTest extends StorageTest
         // delete
         unset($this->storage);
     }
-
 }

--- a/tests/OAuth/Unit/Common/Storage/RedisTest.php
+++ b/tests/OAuth/Unit/Common/Storage/RedisTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -7,21 +8,23 @@
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
 
+namespace OAuth\Unit\Common\Storage;
+
 use OAuth\Common\Storage\Redis;
 use OAuth\Unit\Common\Storage\StorageTest;
 use Predis\Client as Predis;
 
 class RedisTest extends StorageTest
 {
-    const REDIS_HOST   = '127.0.0.1';
-    const REDIS_PORT   = 6379;
+    const REDIS_HOST = '127.0.0.1';
+    const REDIS_PORT = 6379;
 
     public function setUp()
     {
         // connect to a redis daemon
-        $predis = new PRedis(array(
-            'host'   => RedisTest::REDIS_HOST,
-            'port'   => RedisTest::REDIS_PORT,
+        $predis = new Predis(array(
+            'host' => RedisTest::REDIS_HOST,
+            'port' => RedisTest::REDIS_PORT,
         ));
 
         // set it
@@ -36,5 +39,4 @@ class RedisTest extends StorageTest
         // close connection
         $this->storage->getRedis()->quit();
     }
-
 }

--- a/tests/OAuth/Unit/Common/Storage/SessionTest.php
+++ b/tests/OAuth/Unit/Common/Storage/SessionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -6,6 +7,8 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
+namespace OAuth\Unit\Common\Storage;
 
 use OAuth\Common\Storage\Session;
 use OAuth\Unit\Common\Storage\StorageTest;

--- a/tests/OAuth/Unit/Common/Storage/StorageTest.php
+++ b/tests/OAuth/Unit/Common/Storage/StorageTest.php
@@ -1,4 +1,5 @@
-<?php namespace OAuth\Unit\Common\Storage;
+<?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -7,6 +8,8 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
+namespace OAuth\Unit\Common\Storage;
 
 use \OAuth\OAuth2\Token\StdOAuth2Token;
 
@@ -23,8 +26,8 @@ abstract class StorageTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
-        $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param') );
-        $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param') );
+        $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+        $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
         $this->storage->storeAccessToken($service_1, $token_1);
@@ -58,7 +61,7 @@ abstract class StorageTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
-        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param') );
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
         $this->storage->storeAccessToken($service, $token);

--- a/tests/OAuth/Unit/Common/Storage/SymfonySessionTest.php
+++ b/tests/OAuth/Unit/Common/Storage/SymfonySessionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @category   OAuth
  * @package    Tests
@@ -6,6 +7,8 @@
  * @copyright  Copyright (c) 2012 The authors
  * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
  */
+
+namespace OAuth\Unit\Common\Storage;
 
 use OAuth\Common\Storage\SymfonySession;
 use OAuth\Unit\Common\Storage\StorageTest;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Bootstrap the test cases.
  *


### PR DESCRIPTION
Continuation of the fix for #30.

No more spaces after opening control structure parenthesis or before the closing parenthesis. I've also formatted the PHPDoc to more closely follow Symfony2's style.

This was all manual, so I could very well have missed something. The more eyes on it the better :ghost: 
