### PR TITLE
Added CredentailsInterface to allow the use of other Credential Objects

### DIFF
--- a/src/OAuth/Common/Consumer/Credentials.php
+++ b/src/OAuth/Common/Consumer/Credentials.php
@@ -5,7 +5,7 @@ namespace OAuth\Common\Consumer;
 /**
  * Value object for the credentials of an OAuth service.
  */
-class Credentials
+class Credentials implements CredentialsInterface
 {
     /**
      * @var string

--- a/src/OAuth/Common/Consumer/CredentialsInterface.php
+++ b/src/OAuth/Common/Consumer/CredentialsInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OAuth\Common\Consumer;
+
+/**
+ * Credentials Interface, credentials should implement this.
+ */
+interface CredentialsInterface
+{
+    public function __construct($consumerId, $consumerSecret, $callbackUrl);
+
+    /**
+     * @return string
+     */
+    public function getCallbackUrl();
+
+    /**
+     * @return string
+     */
+    public function getConsumerId();
+
+    /**
+     * @return string
+     */
+    public function getConsumerSecret();
+}

--- a/src/OAuth/Common/Service/AbstractService.php
+++ b/src/OAuth/Common/Service/AbstractService.php
@@ -2,7 +2,7 @@
 
 namespace OAuth\Common\Service;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -28,8 +28,11 @@ abstract class AbstractService implements ServiceInterface
      * @param ClientInterface       $httpClient
      * @param TokenStorageInterface $storage
      */
-    public function __construct(Credentials $credentials, ClientInterface $httpClient, TokenStorageInterface $storage)
-    {
+    public function __construct(
+        CredentialsInterface $credentials,
+        ClientInterface $httpClient,
+        TokenStorageInterface $storage
+    ) {
         $this->credentials = $credentials;
         $this->httpClient = $httpClient;
         $this->storage = $storage;

--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -2,7 +2,7 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -27,7 +27,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * {@inheritDoc}
      */
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Service/BitBucket.php
+++ b/src/OAuth/OAuth1/Service/BitBucket.php
@@ -6,7 +6,7 @@ use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -14,7 +14,7 @@ use OAuth\Common\Http\Client\ClientInterface;
 class BitBucket extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -6,7 +6,7 @@ use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -14,7 +14,7 @@ use OAuth\Common\Http\Client\ClientInterface;
 class Etsy extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Service/FitBit.php
+++ b/src/OAuth/OAuth1/Service/FitBit.php
@@ -6,7 +6,7 @@ use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -14,7 +14,7 @@ use OAuth\Common\Http\Client\ClientInterface;
 class FitBit extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Service/ServiceInterface.php
+++ b/src/OAuth/OAuth1/Service/ServiceInterface.php
@@ -2,7 +2,7 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Token\TokenInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -24,7 +24,7 @@ interface ServiceInterface extends BaseServiceInterface
      * @param UriInterface|null     $baseApiUri
      */
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Service/Tumblr.php
+++ b/src/OAuth/OAuth1/Service/Tumblr.php
@@ -6,7 +6,7 @@ use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -14,7 +14,7 @@ use OAuth\Common\Http\Client\ClientInterface;
 class Tumblr extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Service/Twitter.php
+++ b/src/OAuth/OAuth1/Service/Twitter.php
@@ -6,7 +6,7 @@ use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -14,7 +14,7 @@ use OAuth\Common\Http\Client\ClientInterface;
 class Twitter extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,

--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -2,7 +2,7 @@
 
 namespace OAuth\OAuth1\Signature;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\OAuth1\Signature\Exception\UnsupportedHashAlgorithmException;
 
@@ -24,9 +24,9 @@ class Signature implements SignatureInterface
     protected $tokenSecret = null;
 
     /**
-     * @param Credentials $credentials
+     * @param CredentialsInterface $credentials
      */
-    public function __construct(Credentials $credentials)
+    public function __construct(CredentialsInterface $credentials)
     {
         $this->credentials = $credentials;
     }

--- a/src/OAuth/OAuth1/Signature/SignatureInterface.php
+++ b/src/OAuth/OAuth1/Signature/SignatureInterface.php
@@ -2,15 +2,15 @@
 
 namespace OAuth\OAuth1\Signature;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 
 interface SignatureInterface
 {
     /**
-     * @param Credentials $credentials
+     * @param CredentialsInterface $credentials
      */
-    public function __construct(Credentials $credentials);
+    public function __construct(CredentialsInterface $credentials);
 
     /**
      * @param string $algorithm

--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -2,7 +2,7 @@
 
 namespace OAuth\OAuth2\Service;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Exception\Exception;
 use OAuth\Common\Service\AbstractService as BaseAbstractService;
 use OAuth\Common\Storage\TokenStorageInterface;
@@ -35,7 +35,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * @throws InvalidScopeException
      */
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Amazon.php
+++ b/src/OAuth/OAuth2/Service/Amazon.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -26,7 +26,7 @@ class Amazon extends AbstractService
     const SCOPE_POSTAL_CODE = 'postal_code';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Bitly.php
+++ b/src/OAuth/OAuth2/Service/Bitly.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -13,7 +13,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Bitly extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Box.php
+++ b/src/OAuth/OAuth2/Service/Box.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -19,7 +19,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Box extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Dropbox.php
+++ b/src/OAuth/OAuth2/Service/Dropbox.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -19,7 +19,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Dropbox extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -13,7 +13,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Facebook extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -15,7 +15,7 @@ class Foursquare extends AbstractService
     private $apiVersionDate = '20130829';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/GitHub.php
+++ b/src/OAuth/OAuth2/Service/GitHub.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -22,7 +22,7 @@ class GitHub extends AbstractService
     const SCOPE_GIST = 'gist';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Instagram.php
+++ b/src/OAuth/OAuth2/Service/Instagram.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -22,7 +22,7 @@ class Instagram extends AbstractService
     const SCOPE_LIKES         = 'likes';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Linkedin.php
+++ b/src/OAuth/OAuth2/Service/Linkedin.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -32,7 +32,7 @@ class Linkedin extends AbstractService
     const SCOPE_W_MESSAGES     = 'w_messages';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Microsoft.php
+++ b/src/OAuth/OAuth2/Service/Microsoft.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -37,7 +37,7 @@ class Microsoft extends AbstractService
     const SCOPE_APPLICATIONS_CREATE = 'wl.applications_create';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Paypal.php
+++ b/src/OAuth/OAuth2/Service/Paypal.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -32,7 +32,7 @@ class Paypal extends AbstractService
     const SCOPE_EXPRESSCHECKOUT  = 'https://uri.paypal.com/services/expresscheckout';
 
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/ServiceInterface.php
+++ b/src/OAuth/OAuth2/Service/ServiceInterface.php
@@ -2,7 +2,7 @@
 
 namespace OAuth\OAuth2\Service;
 
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Token\TokenInterface;
 use OAuth\Common\Http\Client\ClientInterface;
@@ -31,7 +31,7 @@ interface ServiceInterface extends BaseServiceInterface
      * @param UriInterface|null     $baseApiUri
      */
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/SoundCloud.php
+++ b/src/OAuth/OAuth2/Service/SoundCloud.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -13,7 +13,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class SoundCloud extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Vkontakte.php
+++ b/src/OAuth/OAuth2/Service/Vkontakte.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -13,7 +13,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Vkontakte extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/OAuth2/Service/Yammer.php
+++ b/src/OAuth/OAuth2/Service/Yammer.php
@@ -5,7 +5,7 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
@@ -13,7 +13,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Yammer extends AbstractService
 {
     public function __construct(
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         $scopes = array(),

--- a/src/OAuth/ServiceFactory.php
+++ b/src/OAuth/ServiceFactory.php
@@ -14,7 +14,7 @@
 namespace OAuth;
 
 use OAuth\Common\Service\ServiceInterface;
-use OAuth\Common\Consumer\Credentials;
+use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Http\Client\StreamClient;
@@ -85,7 +85,7 @@ class ServiceFactory
      */
     public function createService(
         $serviceName,
-        Credentials $credentials,
+        CredentialsInterface $credentials,
         TokenStorageInterface $storage,
         $scopes = array()
     ) {


### PR DESCRIPTION
Why?
Currently, it's not possible to write your own Credential's Class to pass into your service provider.

As an example Xero (xero.com) provide a 2 legged private oAuth (v1a) implementation, where both the consumer and user credentials are the same, and all requests as signed with RSA-SHA1 using public/private certs on each end.
