### PR TITLE
Add Base API URI as an argument for service factory

### DIFF
--- a/src/OAuth/ServiceFactory.php
+++ b/src/OAuth/ServiceFactory.php
@@ -18,6 +18,7 @@ use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Http\Client\StreamClient;
+use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\Common\Exception\Exception;
 use OAuth\OAuth1\Signature\Signature;
 
@@ -78,6 +79,7 @@ class ServiceFactory
      * @param Credentials           $credentials
      * @param TokenStorageInterface $storage
      * @param array|null            $scopes      If creating an oauth2 service, array of scopes
+     * @param UriInterface|null     $baseApiUri
      *
      * @return ServiceInterface
      *
@@ -87,7 +89,8 @@ class ServiceFactory
         $serviceName,
         CredentialsInterface $credentials,
         TokenStorageInterface $storage,
-        $scopes = array()
+        $scopes = array(),
+        UriInterface $baseApiUri = null
     ) {
         if (!$this->httpClient) {
             // for backwards compatibility.
@@ -119,7 +122,7 @@ class ServiceFactory
                 }
             }
 
-            return new $v2ClassName($credentials, $this->httpClient, $storage, $resolvedScopes);
+            return new $v2ClassName($credentials, $this->httpClient, $storage, $resolvedScopes, $baseApiUri);
         }
 
         if (class_exists($v1ClassName)) {
@@ -130,7 +133,7 @@ class ServiceFactory
             }
             $signature = new Signature($credentials);
 
-            return new $v1ClassName($credentials, $this->httpClient, $storage, $signature);
+            return new $v1ClassName($credentials, $this->httpClient, $storage, $signature, $baseApiUri);
         }
 
         return null;


### PR DESCRIPTION
At present, $baseApiUri is the last (optional) constructor argument for service classes, but there's no way to pass it to `ServiceFactory::createService`. This commit adds it to the argument list.

There's some potential use cases for this -- for example, targeting different versions of an API, targeting different API hosts based on development / production environment, etc.
