### PR TITLE
Strict comparison for strings and changed init.example.php to old array syntax

### DIFF
--- a/examples/amazon.php
+++ b/examples/amazon.php
@@ -43,7 +43,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique Amazon user id is: ' . $result['user_id'] . ' and your name is ' . $result['name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $amazonService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/bitly.php
+++ b/examples/bitly.php
@@ -44,7 +44,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique user id is: ' . $result['data']['login'] . ' and your name is ' . $result['data']['display_name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $bitlyService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/box.php
+++ b/examples/box.php
@@ -45,7 +45,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your Box name is ' . $result['name'] . ' and your email is ' . $result['login'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $boxService->getAuthorizationUri(array('state' => 'blabla'));
     // var_dump($url);
     header('Location: ' . $url);

--- a/examples/dropbox.php
+++ b/examples/dropbox.php
@@ -43,7 +43,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique Dropbox user id is: ' . $result['uid'] . ' and your name is ' . $result['display_name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $dropboxService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/etsy.php
+++ b/examples/etsy.php
@@ -48,7 +48,7 @@ if (!empty($_GET['oauth_token'])) {
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $response = $etsyService->requestRequestToken();
     $extra = $response->getExtraParams();
     $url = $extra['login_url'];

--- a/examples/facebook.php
+++ b/examples/facebook.php
@@ -45,7 +45,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique facebook user id is: ' . $result['id'] . ' and your name is ' . $result['name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $facebookService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/fitbit.php
+++ b/examples/fitbit.php
@@ -49,7 +49,7 @@ if (!empty($_GET['oauth_token'])) {
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     // extra request needed for oauth1 to request a request token :-)
     $token = $fitbitService->requestRequestToken();
 

--- a/examples/foursquare.php
+++ b/examples/foursquare.php
@@ -44,7 +44,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique foursquare user id is: ' . $result['response']['user']['id'] . ' and your name is ' . $result['response']['user']['firstName'] . $result['response']['user']['lastName'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $foursquareService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/github.php
+++ b/examples/github.php
@@ -42,7 +42,7 @@ if (!empty($_GET['code'])) {
 
     echo 'The first email on your github account is ' . $result[0];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $gitHub->getAuthorizationUri();
     header('Location: ' . $url);
 

--- a/examples/google.php
+++ b/examples/google.php
@@ -44,7 +44,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique google user id is: ' . $result['id'] . ' and your name is ' . $result['name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $googleService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/init.example.php
+++ b/examples/init.example.php
@@ -14,80 +14,80 @@
 /**
  * @var array A list of all the credentials to be used by the different services in the examples
  */
-$servicesCredentials = [
-    'bitly' => [
+$servicesCredentials = array(
+    'bitly' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'facebook' => [
+    ),
+    'facebook' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'github' => [
+    ),
+    'github' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'google' => [
+    ),
+    'google' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'microsoft' => [
+    ),
+    'microsoft' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'yammer' => [
+    ),
+    'yammer' => array(
         'key'       => '',
         'secret'    => ''
-    ],
-    'soundcloud' => [
+    ),
+    'soundcloud' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'foursquare' => [
+    ),
+    'foursquare' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'twitter' => [
+    ),
+    'twitter' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'fitbit' => [
+    ),
+    'fitbit' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'instagram' => [
+    ),
+    'instagram' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'linkedin' => [
+    ),
+    'linkedin' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'box' => [
+    ),
+    'box' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'tumblr' => [
+    ),
+    'tumblr' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'etsy' => [
+    ),
+    'etsy' => array(
         'key'       => '',
         'secret'    => '',
-    ],
-    'amazon' => [
+    ),
+    'amazon' => array(
         'key'		=> '',
         'secret'	=> '',
-    ],
-    'paypal' => [
+    ),
+    'paypal' => array(
         'key'		=> '',
         'secret'	=> '',
-    ],
-    'dropbox' => [
+    ),
+    'dropbox' => array(
         'key'		=> '',
         'secret'	=> '',
-    ],
-];
+    ),
+);
 
 /** @var $serviceFactory \OAuth\ServiceFactory An OAuth service factory. */
 $serviceFactory = new \OAuth\ServiceFactory();

--- a/examples/instagram.php
+++ b/examples/instagram.php
@@ -47,7 +47,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique instagram user id is: ' . $result['data']['id'] . ' and your name is ' . $result['data']['full_name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $instagramService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/linkedin.php
+++ b/examples/linkedin.php
@@ -45,7 +45,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your linkedin first name is ' . $result['firstName'] . ' and your last name is ' . $result['lastName'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     // state is used to prevent CSRF, it's required
     $url = $linkedinService->getAuthorizationUri(array('state' => 'DCEEFWF45453sdffef424'));
     header('Location: ' . $url);

--- a/examples/microsoft.php
+++ b/examples/microsoft.php
@@ -40,7 +40,7 @@ if (!empty($_GET['code'])) {
 
     var_dump($token);
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $microsoft->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/paypal.php
+++ b/examples/paypal.php
@@ -43,7 +43,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique PayPal user id is: ' . $result['user_id'] . ' and your name is ' . $result['name'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $paypalService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/soundcloud.php
+++ b/examples/soundcloud.php
@@ -44,7 +44,7 @@ if (!empty($_GET['code'])) {
     // Show some of the resultant data
     echo 'Your unique user id is: ' . $result['id'] . ' and your name is ' . $result['username'];
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     $url = $soundcloudService->getAuthorizationUri();
     header('Location: ' . $url);
 } else {

--- a/examples/tumblr.php
+++ b/examples/tumblr.php
@@ -50,7 +50,7 @@ if (!empty($_GET['oauth_token'])) {
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     // extra request needed for oauth1 to request a request token :-)
     $token = $tumblrService->requestRequestToken();
 

--- a/examples/twitter.php
+++ b/examples/twitter.php
@@ -50,7 +50,7 @@ if (!empty($_GET['oauth_token'])) {
 
     echo 'result: <pre>' . print_r($result, true) . '</pre>';
 
-} elseif (!empty($_GET['go']) && $_GET['go'] == 'go') {
+} elseif (!empty($_GET['go']) && $_GET['go'] === 'go') {
     // extra request needed for oauth1 to request a request token :-)
     $token = $twitterService->requestRequestToken();
 

--- a/src/OAuth/Common/Http/Uri/Uri.php
+++ b/src/OAuth/Common/Http/Uri/Uri.php
@@ -99,7 +99,7 @@ class Uri implements UriInterface
 
         if (isset($uriParts['path'])) {
             $this->path = $uriParts['path'];
-            if ('/' == $uriParts['path']) {
+            if ('/' === $uriParts['path']) {
                 $this->explicitTrailingHostSlash = true;
             }
         } else {
@@ -245,7 +245,7 @@ class Uri implements UriInterface
     {
         $uri = $this->scheme . '://' . $this->getRawAuthority();
 
-        if ('/' == $this->path) {
+        if ('/' === $this->path) {
             $uri .= $this->explicitTrailingHostSlash ? '/' : '';
         } else {
             $uri .= $this->path;
@@ -269,7 +269,7 @@ class Uri implements UriInterface
     {
         $uri = '';
 
-        if ('/' == $this->path) {
+        if ('/' === $this->path) {
             $uri .= $this->explicitTrailingHostSlash ? '/' : '';
         } else {
             $uri .= $this->path;
@@ -288,7 +288,7 @@ class Uri implements UriInterface
     {
         $uri = $this->scheme . '://' . $this->getAuthority();
 
-        if ('/' == $this->path) {
+        if ('/' === $this->path) {
             $uri .= $this->explicitTrailingHostSlash ? '/' : '';
         } else {
             $uri .= $this->path;

--- a/src/OAuth/OAuth1/Service/BitBucket.php
+++ b/src/OAuth/OAuth1/Service/BitBucket.php
@@ -60,7 +60,7 @@ class BitBucket extends AbstractService
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
+        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
             throw new TokenResponseException('Error in retrieving token.');
         }
 

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -60,7 +60,7 @@ class Etsy extends AbstractService
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
+        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
             throw new TokenResponseException('Error in retrieving token.');
         }
 

--- a/src/OAuth/OAuth1/Service/FitBit.php
+++ b/src/OAuth/OAuth1/Service/FitBit.php
@@ -60,7 +60,7 @@ class FitBit extends AbstractService
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
+        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
             throw new TokenResponseException('Error in retrieving token.');
         }
 

--- a/src/OAuth/OAuth1/Service/Tumblr.php
+++ b/src/OAuth/OAuth1/Service/Tumblr.php
@@ -60,7 +60,7 @@ class Tumblr extends AbstractService
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
+        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
             throw new TokenResponseException('Error in retrieving token.');
         }
 

--- a/src/OAuth/OAuth1/Service/Twitter.php
+++ b/src/OAuth/OAuth1/Service/Twitter.php
@@ -62,7 +62,7 @@ class Twitter extends AbstractService
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
+        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
             throw new TokenResponseException('Error in retrieving token.');
         }
 

--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -67,7 +67,7 @@ class Signature implements SignatureInterface
         // determine base uri
         $baseUri = $uri->getScheme() . '://' . $uri->getRawAuthority();
 
-        if ('/' == $uri->getPath()) {
+        if ('/' === $uri->getPath()) {
             $baseUri .= $uri->hasExplicitTrailingHostSlash() ? '/' : '';
         } else {
             $baseUri .= $uri->getPath();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,7 +26,7 @@ date_default_timezone_set('Europe/Amsterdam');
  */
 spl_autoload_register(function ($class) {
     $nslen = strlen(__NAMESPACE__);
-    if (substr($class, 0, $nslen) != __NAMESPACE__) {
+    if (substr($class, 0, $nslen) !== __NAMESPACE__) {
         return;
     }
     $path = substr(str_replace('\\', '/', $class), $nslen);


### PR DESCRIPTION
Changed string comparison from "==" and "!=" to "===" and "!==", avoiding unexpected behaviors in some cases.
Also changed init.example.php to array() syntax rather than [] so it keeps PHP 5.3 compatibility.
