### PR TITLE
Added support for additional curl_setopt parameters for Curl Http Client

### DIFF
--- a/src/OAuth/Common/Http/Client/CurlClient.php
+++ b/src/OAuth/Common/Http/Client/CurlClient.php
@@ -23,12 +23,14 @@ class CurlClient extends AbstractClient
      *
      * @var array
      */
-    private $parameters;
+    private $parameters = array();
 
     /**
+     * Additional `curl_setopt` parameters
+     *
      * @param array $parameters
      */
-    public function __construct(array $parameters = array())
+    public function setCurlParameters(array $parameters)
     {
         $this->parameters = $parameters;
     }

--- a/tests/Unit/Common/Http/Client/CurlClientTest.php
+++ b/tests/Unit/Common/Http/Client/CurlClientTest.php
@@ -351,7 +351,8 @@ class CurlClientTest extends \PHPUnit_Framework_TestCase
             ->method('getAbsoluteUri')
             ->will($this->returnValue('http://httpbin.org/gzip'));
 
-        $client = new CurlClient(array(
+        $client = new CurlClient();
+        $client->setCurlParameters(array(
             CURLOPT_ENCODING => 'gzip',
         ));
 


### PR DESCRIPTION
The aim of this PR is to provide a way to specify additional curl parameters, such as `CURLOPT_CAINFO` and `CURLOPT_ENCODING`
