### PR TITLE
Added explicit `serialize()` / `unserialize()` for session token storage

### DIFF
--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -37,7 +37,7 @@ class Session implements TokenStorageInterface
     public function retrieveAccessToken($service)
     {
         if ($this->hasAccessToken($service)) {
-            return $_SESSION[$this->sessionVariableName][$service];
+            return unserialize($_SESSION[$this->sessionVariableName][$service]);
         }
 
         throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
@@ -48,13 +48,15 @@ class Session implements TokenStorageInterface
      */
     public function storeAccessToken($service, TokenInterface $token)
     {
+        $serializedToken = serialize($token);
+
         if (isset($_SESSION[$this->sessionVariableName])
             && is_array($_SESSION[$this->sessionVariableName])
         ) {
-            $_SESSION[$this->sessionVariableName][$service] = $token;
+            $_SESSION[$this->sessionVariableName][$service] = $serializedToken;
         } else {
             $_SESSION[$this->sessionVariableName] = array(
-                $service => $token,
+                $service => $serializedToken,
             );
         }
 

--- a/tests/Unit/Common/Storage/SessionTest.php
+++ b/tests/Unit/Common/Storage/SessionTest.php
@@ -222,4 +222,24 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         unset($storage);
     }
+
+    /**
+     * @covers OAuth\Common\Storage\Session::storeAccessToken
+     * @covers OAuth\Common\Storage\Session::retrieveAccessToken
+     *
+     * @runInSeparateProcess
+     */
+    public function testSerializeUnserialize()
+    {
+        $mock = $this->getMock('\\OAuth\\Common\\Token\\AbstractToken', array('__sleep'));
+        $mock->expects($this->once())
+            ->method('__sleep')
+            ->will($this->returnValue(array('accessToken')));
+
+        $storage = new Session();
+        $storage->storeAccessToken('foo', $mock);
+        $retrievedToken = $storage->retrieveAccessToken('foo');
+
+        $this->assertInstanceOf('\\OAuth\\Common\\Token\\AbstractToken', $retrievedToken);
+    }
 }


### PR DESCRIPTION
Proposed solution for https://github.com/Lusitanian/PHPoAuthLib/issues/124
