### PR TITLE
Facebook does not return a expires parameter anymore

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -58,7 +58,6 @@ class Facebook extends AbstractService
 
         $token = new StdOAuth2Token();
         $token->setAccessToken($data['access_token']);
-        $token->setLifeTime($data['expires']);
 
         if (isset($data['refresh_token'])) {
             $token->setRefreshToken($data['refresh_token']);
@@ -66,7 +65,6 @@ class Facebook extends AbstractService
         }
 
         unset($data['access_token']);
-        unset($data['expires']);
 
         $token->setExtraParams($data);
 


### PR DESCRIPTION
Facebook does not return expires parameter anymore in access token response.
