### PR TITLE
Fixed header value in stream_context_create()

### DIFF
--- a/src/OAuth/Common/Http/Client/StreamClient.php
+++ b/src/OAuth/Common/Http/Client/StreamClient.php
@@ -73,7 +73,7 @@ class StreamClient extends AbstractClient
             array(
                 'http' => array(
                     'method'           => $method,
-                    'header'           => join(,"\r\n",array_values($headers)),
+                    'header'           => join("\r\n",array_values($headers)),
                     'content'          => $body,
                     'protocol_version' => '1.1',
                     'user_agent'       => $this->userAgent,


### PR DESCRIPTION
According to http://php.net/manual/en/function.stream-context-create.php should be a string. With my local PHP installation it also works with an array but on Google AppEngine it gives an error message: 'Invalid headers. Must be a string.'
