### PR TITLE
Fixed generateStreamContext to pass 'header' as a string not array

### DIFF
--- a/src/OAuth/Common/Http/Client/StreamClient.php
+++ b/src/OAuth/Common/Http/Client/StreamClient.php
@@ -73,7 +73,7 @@ class StreamClient extends AbstractClient
             array(
                 'http' => array(
                     'method'           => $method,
-                    'header'           => join("\r\n", array_values($headers)),
+                    'header'           => implode("\r\n", array_values($headers)),
                     'content'          => $body,
                     'protocol_version' => '1.1',
                     'user_agent'       => $this->userAgent,


### PR DESCRIPTION
Although the array works locally it fails on Google AppEngine. All the examples on php.net use strings also.
