### PR TITLE
Using string as header not array. Works locally but AppEngine expects a ...

### DIFF
--- a/src/OAuth/Common/Http/Client/StreamClient.php
+++ b/src/OAuth/Common/Http/Client/StreamClient.php
@@ -73,7 +73,7 @@ class StreamClient extends AbstractClient
             array(
                 'http' => array(
                     'method'           => $method,
-                    'header'           => array_values($headers),
+                    'header'           => implode("\r\n", array_values($headers)),
                     'content'          => $body,
                     'protocol_version' => '1.1',
                     'user_agent'       => $this->userAgent,


### PR DESCRIPTION
...string. PHP.net examples also use strings.
