### PR TITLE
added support for Glass Mirror API location and timeline scopes

### DIFF
--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -44,6 +44,10 @@ class Google extends AbstractService
     const SCOPE_USER_PROVISIONING = 'https://apps-apis.google.com/a/feeds/user/';
     const SCOPE_WEBMASTERTOOLS = 'https://www.google.com/webmasters/tools/feeds/';
     const SCOPE_YOUTUBE = 'https://gdata.youtube.com';
+    
+    const SCOPE_GLASS_TIMELINE = 'https://www.googleapis.com/auth/glass.timeline';
+    const SCOPE_GLASS_LOCATION = 'https://www.googleapis.com/auth/glass.location';
+
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This is going to add two constants for oAuth access to the Google Glass Mirror API.  I am aware that the API might not be final, and that scopes might change or be updated as Google gets closer to a release of Glass.  In the mean time, I am using PHPoAuthLib with Laravel4 to build a Glass application.  I had to make the change below to get this library working with my application.

Not every developer can have access to theses APIs, but the permission scopes are public knowledge. 
https://github.com/googleglass/mirror-quickstart-php/blob/master/mirror-client.php
