### PR TITLE
Wrong property path for Yammer

### DIFF
--- a/src/OAuth/OAuth2/Service/Yammer.php
+++ b/src/OAuth/OAuth2/Service/Yammer.php
@@ -64,8 +64,7 @@ class Yammer extends AbstractService
         }
 
         $token = new StdOAuth2Token();
-        $token->setAccessToken($data['access_token']);
-        $token->setLifetime($data['expires_in']);
+        $token->setAccessToken($data['access_token']['token']);
 
         if (isset($data['refresh_token'])) {
             $token->setRefreshToken($data['refresh_token']);


### PR DESCRIPTION
Yammer return's a access_token with extra data like this and the lifetime is null so there is no lifetime.

```
Array
(
    [access_token] => Array
        (
            [user_id] => 1503941481
            [network_id] => 916484
            [network_permalink] => jcid.nl
            [network_name] => jcid.nl
            [token] => <token>
            [view_members] => 1
            [view_groups] => 1
            [view_messages] => 1
            [view_subscriptions] => 1
            [modify_subscriptions] => 1
            [modify_messages] => 1
            [view_tags] => 1
            [created_at] => 2013/11/12 09:36:49 +0000
            [authorized_at] => 2013/11/12 09:36:49 +0000
            [expires_at] => 
        )
}
```
