### PR TITLE
Wrong property path for Yammer

### DIFF
--- a/src/OAuth/OAuth2/Service/Yammer.php
+++ b/src/OAuth/OAuth2/Service/Yammer.php
@@ -64,8 +64,8 @@ class Yammer extends AbstractService
         }
 
         $token = new StdOAuth2Token();
-        $token->setAccessToken($data['access_token']);
-        $token->setLifetime($data['expires_in']);
+        $token->setAccessToken($data['access_token']['token']);
+        $token->setLifetime($data['access_token']['expires_at']);
 
         if (isset($data['refresh_token'])) {
             $token->setRefreshToken($data['refresh_token']);

--- a/tests/Unit/OAuth2/Service/YammerTest.php
+++ b/tests/Unit/OAuth2/Service/YammerTest.php
@@ -156,7 +156,7 @@ class YammerTest extends \PHPUnit_Framework_TestCase
     public function testParseAccessTokenResponseValidWithoutRefreshToken()
     {
         $client = $this->getMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
-        $client->expects($this->once())->method('retrieveResponse')->will($this->returnValue('{"access_token":"foo","expires_in":"bar"}'));
+        $client->expects($this->once())->method('retrieveResponse')->will($this->returnValue('{"access_token":{"token":"foo", "expires_at":null}}'));
 
         $service = new Yammer(
             $this->getMock('\\OAuth\\Common\\Consumer\\CredentialsInterface'),
@@ -174,7 +174,7 @@ class YammerTest extends \PHPUnit_Framework_TestCase
     public function testParseAccessTokenResponseValidWithRefreshToken()
     {
         $client = $this->getMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
-        $client->expects($this->once())->method('retrieveResponse')->will($this->returnValue('{"access_token":"foo","expires_in":"bar","refresh_token":"baz"}'));
+        $client->expects($this->once())->method('retrieveResponse')->will($this->returnValue('{"access_token":{"token":"foo", "expires_at":null},"refresh_token":"baz"}'));
 
         $service = new Yammer(
             $this->getMock('\\OAuth\\Common\\Consumer\\CredentialsInterface'),


### PR DESCRIPTION
Yammer return's a access_token with extra data like this and the lifetime is null so there is no lifetime. Sorry for a second pull request but I removed my old branch but updated the tests with this pull request. More info about the acces_token of Yammer can be found here http://developer.yammer.com/authentication/. 

```
Array
(
    [access_token] => Array
        (
            [user_id] => 1503941481
            [network_id] => 916484
            [network_permalink] => jcid.nl
            [network_name] => jcid.nl
            [token] => <token>
            [view_members] => 1
            [view_groups] => 1
            [view_messages] => 1
            [view_subscriptions] => 1
            [modify_subscriptions] => 1
            [modify_messages] => 1
            [view_tags] => 1
            [created_at] => 2013/11/12 09:36:49 +0000
            [authorized_at] => 2013/11/12 09:36:49 +0000
            [expires_at] => 
        )
}
```
