### PR TITLE
Facebook service must parse JSON for now

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -146,7 +146,7 @@ class Facebook extends AbstractService
                 $errorString = $data['error'];
                 $code = 0;
             }
-            throw new TokenResponseException('Error in retrieving token: "' . $errorString . '"',$code);
+            throw new TokenResponseException('Error in retrieving token: "' . $errorString . '"', $code);
         }
 
         $token = new StdOAuth2Token();


### PR DESCRIPTION
Facebook OAuth can return token as JSON. First it was issued 3 days ago.
