### PR TITLE
Added possibility to add oauth token to storage after service constructor

### DIFF
--- a/src/OAuth/OAuth2/Service/Mailchimp.php
+++ b/src/OAuth/OAuth2/Service/Mailchimp.php
@@ -22,12 +22,8 @@ class Mailchimp extends AbstractService
     ) {
         parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
 
-        if (is_null($baseApiUri)) {
-            if ($storage->hasAccessToken($this->service())) {
-                $this->setBaseApiUri($storage->retrieveAccessToken($this->service()));
-            } else {
-                $this->baseApiUri = new Uri('https://us1.api.mailchimp.com/2.0/');
-            }
+        if (is_null($this->baseApiUri) && $storage->hasAccessToken($this->service())) {
+            $this->setBaseApiUri($storage->retrieveAccessToken($this->service()));
         }
     }
 
@@ -80,6 +76,18 @@ class Mailchimp extends AbstractService
         $token->setEndOfLife(StdOAuth2Token::EOL_NEVER_EXPIRES);
 
         return $token;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        if (is_null($this->baseApiUri)) {
+            $this->setBaseApiUri($this->storage->retrieveAccessToken($this->service()));
+        }
+
+        return parent::request($path, $method, $body, $extraHeaders);
     }
 
     /**

--- a/tests/Unit/OAuth2/Service/MailchimpTest.php
+++ b/tests/Unit/OAuth2/Service/MailchimpTest.php
@@ -4,6 +4,7 @@ namespace OAuthTest\Unit\OAuth2\Service;
 
 use OAuth\OAuth2\Service\Mailchimp;
 use OAuth\Common\Token\TokenInterface;
+use OAuth\Common\Http\Uri\Uri;
 
 class MailchimpTest extends \PHPUnit_Framework_TestCase
 {
@@ -96,7 +97,7 @@ class MailchimpTest extends \PHPUnit_Framework_TestCase
         $client = $this->getMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
         $client->expects($this->once())->method('retrieveResponse')->will($this->returnArgument(0));
 
-        $token = $this->getMock('\\OAuth\\OAuth2\\Token\\TokenInterface');
+        $token = $this->getMock('\\OAuth\\OAuth2\\Token\\StdOAuth2Token');
         $token->expects($this->once())->method('getEndOfLife')->will($this->returnValue(TokenInterface::EOL_NEVER_EXPIRES));
         $token->expects($this->once())->method('getAccessToken')->will($this->returnValue('foo'));
 
@@ -106,7 +107,9 @@ class MailchimpTest extends \PHPUnit_Framework_TestCase
         $service = new Mailchimp(
             $this->getMock('\\OAuth\\Common\\Consumer\\CredentialsInterface'),
             $client,
-            $storage
+            $storage,
+            array(),
+            new Uri('https://us1.api.mailchimp.com/2.0/')
         );
 
         $uri         = $service->request('https://pieterhordijk.com/my/awesome/path');


### PR DESCRIPTION
Added possibility to add oauth token to storage after service constructor is called and still get the service to call the right DC
