### PR TITLE
Renamed Salesforce service class

### DIFF
--- a/src/OAuth/OAuth2/Service/Salesforce.php
+++ b/src/OAuth/OAuth2/Service/Salesforce.php
@@ -11,7 +11,7 @@ use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Http\Uri\UriInterface;
 
-class SalesforceService extends AbstractService
+class Salesforce extends AbstractService
 {
     /**
      * Scopes


### PR DESCRIPTION
The Salesforce class has been named incorrectly. This fixes the invalid class name.