### PR TITLE
Adding Guzzle Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "guzzle/guzzle": "3.*"
     },
     "require-dev": {
         "symfony/http-foundation": "~2.1",

--- a/src/OAuth/Common/Http/Client/GuzzleClient.php
+++ b/src/OAuth/Common/Http/Client/GuzzleClient.php
@@ -1,0 +1,51 @@
+<?php
+namespace OAuth\Common\Http\Client;
+
+use OAuth\Common\Http\Exception\TokenResponseException;
+use OAuth\Common\Http\Exception\GuzzleException;
+use OAuth\Common\Http\Uri\UriInterface;
+
+/**
+ * Client implementation for Guzzle
+ */
+class GuzzleClient extends AbstractClient
+{
+    protected $client;
+    protected $lastResponse;
+
+    public function retrieveResponse(
+        UriInterface $endpoint,
+        $requestBody,
+        array $extraHeaders = array(),
+        $method = 'POST'
+    ) {
+
+        try {
+            $request = $this->client()->createRequest($method, $endpoint, $extraHeaders, $requestBody);
+            $this->lastResponse = $request->send();
+            return $this->lastResponse->getBody();
+
+        } catch (\Guzzle\Http\Exception\ClientErrorResponseException $e) {
+            $this->lastResponse = $e->getResponse();
+            // See http://docs.guzzlephp.org/en/latest/http-client/response.html
+
+            $http_status = $this->lastResponse->getStatusCode();
+            $guzzleException = new GuzzleException("Guzzle HTTP {$http_status} Error");
+            $guzzleException->setGuzzleResponse($this->lastResponse);
+            throw $guzzleException;
+        }
+    }
+
+    private function client()
+    {
+        if (!isset($this->client)) {
+            $this->client = new \Guzzle\Http\Client();
+        }
+        return $this->client;
+    }
+
+    public function getLastResponse()
+    {
+        return $this->lastResponse;
+    }
+}

--- a/src/OAuth/Common/Http/Exception/GuzzleException.php
+++ b/src/OAuth/Common/Http/Exception/GuzzleException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OAuth\Common\Http\Exception;
+
+use OAuth\Common\Exception\Exception;
+
+class GuzzleException extends Exception
+{
+    protected $response;
+
+    public function getGuzzleResponse()
+    {
+        return $this->response;
+    }
+
+    public function setGuzzleResponse($response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/OAuth/Common/Service/AbstractService.php
+++ b/src/OAuth/Common/Service/AbstractService.php
@@ -88,6 +88,16 @@ abstract class AbstractService implements ServiceInterface
     }
 
     /**
+     * Accessor to the http client
+     *
+     * @return TokenStorageInterface
+     */
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    /**
      * @return string
      */
     public function service()


### PR DESCRIPTION
Clean-up of my previous pull request #155.

Basic implementation of Guzzle HTTP client. Includes the ability to catch Guzzle Exceptions for non-2XX HTTP status codes, and thus read the HTTP body for errors and other important information

Sample Usage:

```
$serviceFactory = new \OAuth\ServiceFactory();
$guzzleClient = new OAuth\Common\Http\Client\GuzzleClient;
$serviceFactory->setHttpClient($guzzleClient);

$slapi = $serviceFactory->createService('SellerLabs', $credentials, $storage);

try {
    $response = $slapi->request('/foo', 'GET');
} catch (OAuth\Common\Http\Exception\GuzzleException $e) {
    $response = $e->getGuzzleResponse();
    $http_status = $response->getStatusCode();
    echo "<h4>SLAPI Request returned a HTTP {$http_status} error</h4>\n"; 
    $error = $response->getBody();
    echo "Raw Response:\n<pre>". $error. "</pre>\n";
}
```
