### PR TITLE
add read-only scope for Google calendar

### DIFF
--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -53,6 +53,7 @@ class Google extends AbstractService
     const SCOPE_BOOKS                       = 'https://www.googleapis.com/auth/books';
     const SCOPE_BLOGGER                     = 'https://www.googleapis.com/auth/blogger';
     const SCOPE_CALENDAR                    = 'https://www.googleapis.com/auth/calendar';
+    const SCOPE_CALENDAR_READ_ONLY          = 'https://www.googleapis.com/auth/calendar.readonly';
     const SCOPE_CONTACT                     = 'https://www.google.com/m8/feeds/';
     const SCOPE_CHROMEWEBSTORE              = 'https://www.googleapis.com/auth/chromewebstore.readonly';
     const SCOPE_GMAIL                       = 'https://mail.google.com/mail/feed/atom';


### PR DESCRIPTION
I tried to use the read-only scope for Google calendar and saw that it's missing
