### PR TITLE
Adding support for Laravel Session storage backend

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,13 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
+        "illuminate/session": "~4.1",
         "symfony/http-foundation": "~2.1",
         "predis/predis": "0.8.*@dev",
         "phpunit/phpunit": "3.7.*"
     },
     "suggest": {
+        "illuminate/session": "Allows using the Laravel Session storage backend.",
         "symfony/http-foundation": "Allows using the Symfony Session storage backend.",
         "predis/predis": "Allows using the Redis storage backend.",
         "ext-openssl": "Allows for usage of secure connections with the stream-based HTTP client."

--- a/src/OAuth/Common/Storage/LaravelSession.php
+++ b/src/OAuth/Common/Storage/LaravelSession.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace OAuth\Common\Storage;
+
+use OAuth\Common\Token\TokenInterface;
+use OAuth\Common\Storage\Exception\TokenNotFoundException;
+use OAuth\Common\Storage\Exception\AuthorizationStateNotFoundException;
+use Illuminate\Session\Store;
+
+/**
+ * Stores a token in a PHP session.
+ */
+class LaravelSession implements TokenStorageInterface
+{
+    /**
+     * @var object|Store
+     */
+    protected $session;
+
+    /**
+     * @var string
+     */
+    protected $sessionVariableName;
+
+    /**
+     * @var string
+     */
+    protected $stateVariableName;
+
+    /**
+     * @param string $sessionVariableName
+     * @param string $stateVariableName
+     */
+    public function __construct(
+        Store $session,
+        $sessionVariableName = 'lusitanian_oauth_token',
+        $stateVariableName = 'lusitanian_oauth_state'
+    ) {
+        $this->session = $session;
+        $this->sessionVariableName = $sessionVariableName;
+        $this->stateVariableName = $stateVariableName;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveAccessToken($service)
+    {
+        if ($this->hasAccessToken($service)) {
+            return unserialize($this->session->get("$this->sessionVariableName.$service"));
+        }
+
+        throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function storeAccessToken($service, TokenInterface $token)
+    {
+        $this->session->set("$this->sessionVariableName.$service", serialize($token));
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAccessToken($service)
+    {
+        return $this->session->has("$this->sessionVariableName.$service");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearToken($service)
+    {
+        $this->session->forget("$this->sessionVariableName.$service");
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAllTokens()
+    {
+        $this->session->forget($this->sessionVariableName);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function storeAuthorizationState($service, $state)
+    {
+        $this->session->set("$this->stateVariableName.$service", $state);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAuthorizationState($service)
+    {
+        return $this->session->has("$this->stateVariableName.$service");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveAuthorizationState($service)
+    {
+        if ($this->hasAuthorizationState($service)) {
+            return $this->session->get("$this->stateVariableName.$service");
+        }
+
+        throw new AuthorizationStateNotFoundException('State not found in session, are you sure you stored it?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAuthorizationState($service)
+    {
+        $this->session->forget("$this->stateVariableName.$service");
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAllAuthorizationStates()
+    {
+        $this->session->forget($this->stateVariableName);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * @return Session
+     */
+    public function getSession()
+    {
+        return $this->session;
+    }
+}

--- a/tests/Unit/Common/Storage/LaravelSessionTest.php
+++ b/tests/Unit/Common/Storage/LaravelSessionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @category   OAuth
+ * @package    Tests
+ * @author     David Desberg <david@daviddesberg.com>
+ * @copyright  Copyright (c) 2012 The authors
+ * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+
+namespace OAuth\Unit\Common\Storage;
+
+use OAuth\Common\Storage\LaravelSession;
+use OAuth\OAuth2\Token\StdOAuth2Token;
+use Illuminate\Session\Store;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+
+class LaravelSessionTest extends \PHPUnit_Framework_TestCase
+{
+    protected $session;
+
+    protected $storage;
+
+    public function setUp()
+    {
+        // set it
+        $this->session = new Store('name', new NullSessionHandler, 1);
+        $this->storage = new LaravelSession($this->session);
+    }
+
+    public function tearDown()
+    {
+        // delete
+        $this->storage->getSession()->clear();
+        unset($this->storage);
+    }
+
+    /**
+     * Check that the token survives the constructor
+     */
+    public function testStorageSurvivesConstructor()
+    {
+        $service = 'Facebook';
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service, $token);
+        $this->storage = null;
+        $this->storage = new LaravelSession($this->session);
+
+        // assert
+        $extraParams = $this->storage->retrieveAccessToken($service)->getExtraParams();
+        $this->assertEquals('param', $extraParams['extra']);
+        $this->assertEquals($token, $this->storage->retrieveAccessToken($service));
+    }
+
+    /**
+     * Check that the token gets properly stored.
+     */
+    public function testStorage()
+    {
+        // arrange
+        $service_1 = 'Facebook';
+        $service_2 = 'Foursquare';
+
+        $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+        $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $token_2);
+
+        // assert
+        $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
+        $this->assertEquals('param', $extraParams['extra']);
+        $this->assertEquals($token_1, $this->storage->retrieveAccessToken($service_1));
+        $this->assertEquals($token_2, $this->storage->retrieveAccessToken($service_2));
+    }
+
+    /**
+     * Test hasAccessToken.
+     */
+    public function testHasAccessToken()
+    {
+        // arrange
+        $service = 'Facebook';
+        $this->storage->clearToken($service);
+
+        // act
+        // assert
+        $this->assertFalse($this->storage->hasAccessToken($service));
+    }
+
+    /**
+     * Check that the token gets properly deleted.
+     */
+    public function testStorageClears()
+    {
+        // arrange
+        $service = 'Facebook';
+        $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
+
+        // act
+        $this->storage->storeAccessToken($service, $token);
+        $this->storage->clearToken($service);
+
+        // assert
+        $this->setExpectedException('OAuth\Common\Storage\Exception\TokenNotFoundException');
+        $this->storage->retrieveAccessToken($service);
+    }
+}


### PR DESCRIPTION
Example usage within a Laravel application.

``` php
$storage = new \OAuth\Common\Storage\LaravelSession(App::make('session')->driver());
```
