### PR TITLE
Fix session storage bug

### DIFF
--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -12,6 +12,11 @@ use OAuth\Common\Storage\Exception\AuthorizationStateNotFoundException;
 class Session implements TokenStorageInterface
 {
     /**
+     * @var bool
+     */
+    protected $startSession;
+
+    /**
      * @var string
      */
     protected $sessionVariableName;
@@ -35,6 +40,7 @@ class Session implements TokenStorageInterface
             session_start();
         }
 
+        $this->startSession = $startSession;
         $this->sessionVariableName = $sessionVariableName;
         $this->stateVariableName = $stateVariableName;
         if (!isset($_SESSION[$sessionVariableName])) {
@@ -175,6 +181,8 @@ class Session implements TokenStorageInterface
 
     public function __destruct()
     {
-        session_write_close();
+        if ($this->startSession) {
+            session_write_close();
+        }
     }
 }


### PR DESCRIPTION
The Session storage class should not close the session if we pass the first parameter `$startSession` to `false`.

The library should not decide to call `session_write_close()` automatically in the destructor because the session is already handled by the application. The application might want to continue writing in the php session despite the fact the Session Storage instance is destroyed.
