### PR TITLE
Fix oauth_verifier not sent

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -203,10 +203,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         }
 
         $parameters = array_merge($parameters, array('oauth_token' => $token->getAccessToken()));
-
-        $mergedParams = (is_array($bodyParams)) ? array_merge($parameters, $bodyParams) : $parameters;
-
-        $parameters['oauth_signature'] = $this->signature->getSignature($uri, $mergedParams, $method);
+        $parameters = (is_array($bodyParams)) ? array_merge($parameters, $bodyParams) : $parameters;
+        $parameters['oauth_signature'] = $this->signature->getSignature($uri, $parameters, $method);
 
         $authorizationHeader = 'OAuth ';
         $delimiter = '';


### PR DESCRIPTION
`oauth_verifier` wasn't being sent to Yahoo correctly when trying to get an
access token. this makes sure that it makes it into the Authorization header. +
removes an unused assignment.
