### PR TITLE
Scope fix

### DIFF
--- a/src/OAuth/OAuth2/Service/Vkontakte.php
+++ b/src/OAuth/OAuth2/Service/Vkontakte.php
@@ -32,6 +32,7 @@ class Vkontakte extends AbstractService
     const SCOPE_WALL          = 'wall';
     const SCOPE_GROUPS        = 'groups';
     const SCOPE_MESSAGES      = 'messages';
+    const SCOPE_EMAIL         = 'email';
     const SCOPE_NOTIFICATIONS = 'notifications';
     const SCOPE_STATS         = 'stats';
     const SCOPE_ADS           = 'ads';


### PR DESCRIPTION
Add "email" scope. 
This group of rights is only visible in Russian language (documentation bug?): http://vk.com/dev/permissions

Quote: "email (+4194304)    Доступ к email пользователя. Доступно только для сайтов."
