### PR TITLE
Reddit scopes must be comma separated. Fixes #293

### DIFF
--- a/src/OAuth/OAuth2/Service/Reddit.php
+++ b/src/OAuth/OAuth2/Service/Reddit.php
@@ -51,6 +51,39 @@ class Reddit extends AbstractService
     /**
      * {@inheritdoc}
      */
+    public function getAuthorizationUri(array $additionalParameters = array())
+    {
+        $parameters = array_merge(
+            $additionalParameters,
+            array(
+                'type'          => 'web_server',
+                'client_id'     => $this->credentials->getConsumerId(),
+                'redirect_uri'  => $this->credentials->getCallbackUrl(),
+                'response_type' => 'code',
+            )
+        );
+
+        $parameters['scope'] = implode(',', $this->scopes);
+
+        if ($this->needsStateParameterInAuthUrl()) {
+            if (!isset($parameters['state'])) {
+                $parameters['state'] = $this->generateAuthorizationState();
+            }
+            $this->storeAuthorizationState($parameters['state']);
+        }
+
+        // Build the url
+        $url = clone $this->getAuthorizationEndpoint();
+        foreach ($parameters as $key => $val) {
+            $url->addToQuery($key, $val);
+        }
+
+        return $url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getAuthorizationEndpoint()
     {
         return new Uri('https://ssl.reddit.com/api/v1/authorize');


### PR DESCRIPTION
As per - https://github.com/reddit/reddit/wiki/OAuth2

"Note: This is a slight deviation from the OAuth 2.0 specification, which states scopes should normally be space-separated."