### PR TITLE
Flickr: Remove Whitespace and add ability to request format

### DIFF
--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -13,7 +13,8 @@ use OAuth\Common\Http\Client\ClientInterface;
 
 class Flickr extends AbstractService
 {
-    
+    protected $format;
+
     public function __construct(
         CredentialsInterface $credentials,
         ClientInterface $httpClient,
@@ -26,22 +27,22 @@ class Flickr extends AbstractService
             $this->baseApiUri = new Uri('https://api.flickr.com/services/rest/');
         }
     }
-    
+
     public function getRequestTokenEndpoint()
     {
         return new Uri('https://www.flickr.com/services/oauth/request_token');
     }
-    
+
     public function getAuthorizationEndpoint()
     {
         return new Uri('https://www.flickr.com/services/oauth/authorize');
     }
-    
+
     public function getAccessTokenEndpoint()
     {
         return new Uri('https://www.flickr.com/services/oauth/access_token');
     }
-    
+
     protected function parseRequestTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
@@ -52,7 +53,7 @@ class Flickr extends AbstractService
         }
         return $this->parseAccessTokenResponse($responseBody);
     }
-    
+
     protected function parseAccessTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
@@ -61,7 +62,7 @@ class Flickr extends AbstractService
         } elseif (isset($data['error'])) {
             throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
         }
-        
+
         $token = new StdOAuth1Token();
         $token->setRequestToken($data['oauth_token']);
         $token->setRequestTokenSecret($data['oauth_token_secret']);
@@ -70,22 +71,59 @@ class Flickr extends AbstractService
         $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
         unset($data['oauth_token'], $data['oauth_token_secret']);
         $token->setExtraParams($data);
-        
+
         return $token;
     }
-    
+
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $uri = $this->determineRequestUriFromPath('/', $this->baseApiUri);
         $uri->addToQuery('method', $path);
-        
+
+        if (!empty($this->format)) {
+            $uri->addToQuery('format', $this->format);
+        }
+
         $token = $this->storage->retrieveAccessToken($this->service());
         $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);
         $authorizationHeader = array(
             'Authorization' => $this->buildAuthorizationHeaderForAPIRequest($method, $uri, $token, $body)
         );
         $headers = array_merge($authorizationHeader, $extraHeaders);
-        
+
         return $this->httpClient->retrieveResponse($uri, $body, $headers, $method);
+    }
+
+    public function requestRest($path, $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        return $this->request($path, $method, $body, $extraHeaders);
+    }
+
+    public function requestXmlrpc($path, $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        $this->format = 'xmlrpc';
+
+        return $this->request($path, $method, $body, $extraHeaders);
+    }
+
+    public function requestSoap($path, $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        $this->format = 'soap';
+
+        return $this->request($path, $method, $body, $extraHeaders);
+    }
+
+    public function requestJson($path, $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        $this->format = 'json';
+
+        return $this->request($path, $method, $body, $extraHeaders);
+    }
+
+    public function requestPhp($path, $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        $this->format = 'php_serial';
+
+        return $this->request($path, $method, $body, $extraHeaders);
     }
 }

--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -82,9 +82,9 @@ class Flickr extends AbstractService
 
         if (!empty($this->format)) {
             $uri->addToQuery('format', $this->format);
-            
+
             if ($this->format === 'json') {
-                $uri->addToQuery('nojsoncallback', 1)
+                $uri->addToQuery('nojsoncallback', 1);
             }
         }
 

--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -82,6 +82,10 @@ class Flickr extends AbstractService
 
         if (!empty($this->format)) {
             $uri->addToQuery('format', $this->format);
+            
+            if ($this->format === 'json') {
+                $uri->addToQuery('nojsoncallback', 1)
+            }
         }
 
         $token = $this->storage->retrieveAccessToken($this->service());


### PR DESCRIPTION
This update adds the ability to request the format in any of the 5 formats available;
- REST (Default)
- XML-RPC
- SOAP
- JSON
- PHP