### PR TITLE
New scope for Google AdWords

### DIFF
--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -40,7 +40,7 @@ class Google extends AbstractService
 
     // Adwords
     const SCOPE_ADSENSE                     = 'https://www.googleapis.com/auth/adsense';
-    const SCOPE_ADWORDS                     = 'https://adwords.google.com/api/adwords/';
+    const SCOPE_ADWORDS                     = 'https://www.googleapis.com/auth/adwords/';
     const SCOPE_GAN                         = 'https://www.googleapis.com/auth/gan'; // google affiliate network...?
 
     // Google Analytics


### PR DESCRIPTION
As of of v201406 Google AdWords uses new scope for OAuth authorization. Old one is deprecated but still working though.

Source: http://googleadsdeveloper.blogspot.com/2014/07/new-oauth-20-scope-for-adwords-api.html