### PR TITLE
Added PLAINTEXT signature algorithm

### DIFF
--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -77,7 +77,11 @@ class Signature implements SignatureInterface
         $baseString .= rawurlencode($baseUri) . '&';
         $baseString .= rawurlencode($this->buildSignatureDataString($signatureData));
 
-        return base64_encode($this->hash($baseString));
+        if (strtoupper($this->algorithm) == 'PLAINTEXT') {
+            return $this->getSigningKey();
+        } else {
+            return base64_encode($this->hash($baseString));
+        }
     }
 
     /**


### PR DESCRIPTION
I had to access a https based webservice that does not accept any of the HMAC-SHA1 signatures - even though it claims to support them. In the end I switched to PLAINTEXT signature, but I had to add support for that in your signature class.

http://oauth.net/core/1.0/#anchor22

Here is the simple implementation of that in your library.