### PR TITLE
Update Github Scopes

### DIFF
--- a/src/OAuth/OAuth2/Service/GitHub.php
+++ b/src/OAuth/OAuth2/Service/GitHub.php
@@ -87,6 +87,36 @@ class GitHub extends AbstractService
      */
     const SCOPE_HOOKS_ADMIN = 'admin:repo_hook';
 
+    /**
+     * Read-only access to organization, teams, and membership.
+     */
+    const SCOPE_READ_ORG = 'read:org';
+
+    /**
+     * Publicize and unpublicize organization membership.
+     */
+    const SCOPE_WRITE_ORG = 'write:org';
+
+    /**
+     * Fully manage organization, teams, and memberships.
+     */
+    const SCOPE_ADMIN_ORG = 'admin:org';
+
+    /**
+     * List and view details for public keys.
+     */
+    const SCOPE_READ_PUBLIC_KEY = 'read:public_key';
+
+    /**
+     * Create, list, and view details for public keys.
+     */
+    const SCOPE_WRITE_PUBLIC_KEY = 'write:public_key';
+
+    /**
+     * Fully manage public keys.
+     */
+    const SCOPE_ADMIN_PUBLIC_KEY = 'admin:public_key';
+
     public function __construct(
         CredentialsInterface $credentials,
         ClientInterface $httpClient,


### PR DESCRIPTION
GitHub [added 6 new scopes](https://developer.github.com/changes/2014-02-25-organization-oauth-scopes/) February, 2014.

Follow-up on #153.

The DocBlock descriptions are straight from the GitHub Oauth documentation.
