### PR TITLE
Add support for CSRF state hashes for Facebook, Instagram and Google

### DIFF
--- a/examples/facebook.php
+++ b/examples/facebook.php
@@ -36,8 +36,11 @@ $credentials = new Credentials(
 $facebookService = $serviceFactory->createService('facebook', $credentials, $storage, array());
 
 if (!empty($_GET['code'])) {
+    // retrieve the CSRF state parameter
+    $state = isset($_GET['state']) ? $_GET['state'] : null;
+
     // This was a callback request from facebook, get the token
-    $token = $facebookService->requestAccessToken($_GET['code']);
+    $token = $facebookService->requestAccessToken($_GET['code'], $state);
 
     // Send a request with it
     $result = json_decode($facebookService->request('/me'), true);

--- a/examples/google.php
+++ b/examples/google.php
@@ -42,7 +42,7 @@ if (!empty($_GET['code'])) {
     $googleService->requestAccessToken($_GET['code'], $state);
 
     // Send a request with it
-    $result = json_decode($googleService->request('https://www.googleapis.com/oauth2/v1/userinfo'), true);
+    $result = json_decode($googleService->request('userinfo'), true);
 
     // Show some of the resultant data
     echo 'Your unique google user id is: ' . $result['id'] . ' and your name is ' . $result['name'];

--- a/examples/google.php
+++ b/examples/google.php
@@ -35,8 +35,11 @@ $credentials = new Credentials(
 $googleService = $serviceFactory->createService('google', $credentials, $storage, array('userinfo_email', 'userinfo_profile'));
 
 if (!empty($_GET['code'])) {
+    // retrieve the CSRF state parameter
+    $state = isset($_GET['state']) ? $_GET['state'] : null;
+
     // This was a callback request from google, get the token
-    $googleService->requestAccessToken($_GET['code']);
+    $googleService->requestAccessToken($_GET['code'], $state);
 
     // Send a request with it
     $result = json_decode($googleService->request('https://www.googleapis.com/oauth2/v1/userinfo'), true);

--- a/examples/instagram.php
+++ b/examples/instagram.php
@@ -38,8 +38,11 @@ $scopes = array('basic', 'comments', 'relationships', 'likes');
 $instagramService = $serviceFactory->createService('instagram', $credentials, $storage, $scopes);
 
 if (!empty($_GET['code'])) {
+    // retrieve the CSRF state parameter
+    $state = isset($_GET['state']) ? $_GET['state'] : null;
+
     // This was a callback request from Instagram, get the token
-    $instagramService->requestAccessToken($_GET['code']);
+    $instagramService->requestAccessToken($_GET['code'], $state);
 
     // Send a request with it
     $result = json_decode($instagramService->request('users/self'), true);

--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -123,7 +123,7 @@ class Facebook extends AbstractService
         $scopes = array(),
         UriInterface $baseApiUri = null
     ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
 
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://graph.facebook.com/');

--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -2,6 +2,10 @@
 
 namespace OAuth\OAuth2\Service;
 
+use OAuth\Common\Consumer\CredentialsInterface;
+use OAuth\Common\Http\Client\ClientInterface;
+use OAuth\Common\Http\Uri\UriInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\OAuth2\Service\Exception\InvalidAccessTypeException;
@@ -95,6 +99,19 @@ class Google extends AbstractService
 
     protected $accessType = 'online';
 
+    public function __construct(
+        CredentialsInterface $credentials,
+        ClientInterface $httpClient,
+        TokenStorageInterface $storage,
+        $scopes = array(),
+        UriInterface $baseApiUri = null
+    ) {
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
+
+        if (null === $baseApiUri) {
+            $this->baseApiUri = new Uri('https://www.googleapis.com/oauth2/v1/');
+        }
+    }
 
     public function setAccessType($accessType)
     {

--- a/src/OAuth/OAuth2/Service/Instagram.php
+++ b/src/OAuth/OAuth2/Service/Instagram.php
@@ -28,7 +28,7 @@ class Instagram extends AbstractService
         $scopes = array(),
         UriInterface $baseApiUri = null
     ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
+        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
 
         if (null === $baseApiUri) {
             $this->baseApiUri = new Uri('https://api.instagram.com/v1/');


### PR DESCRIPTION
This PR copies the Linkedin implementation of using `state` request parameter to obtain access tokens from... Linkedin. The same feature is supported by Facebook, Instagram and Google. This PR makes it available to use this feature with those Services.