### PR TITLE
Remove 'oauth_verifier' from body of requestAccessToken

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -82,22 +82,20 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         }
         $this->signature->setTokenSecret($tokenSecret);
 
-        $bodyParams = array(
-            'oauth_verifier' => $verifier,
-        );
-
         $authorizationHeader = array(
             'Authorization' => $this->buildAuthorizationHeaderForAPIRequest(
                 'POST',
                 $this->getAccessTokenEndpoint(),
                 $this->storage->retrieveAccessToken($this->service()),
-                $bodyParams
+                array(
+                    'oauth_verifier' => $verifier,
+                )
             )
         );
 
         $headers = array_merge($authorizationHeader, $this->getExtraOAuthHeaders());
 
-        $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), $bodyParams, $headers);
+        $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), null, $headers);
 
         $token = $this->parseAccessTokenResponse($responseBody);
         $this->storage->storeAccessToken($this->service(), $token);


### PR DESCRIPTION
Remove 'oauth_verifier' from body of requestAccessToken as it’s already being sent in the headers.

See section 3.5.  Parameter Transmission of spec here:
http://tools.ietf.org/html/rfc5849#section-3.5

```
When making an OAuth-authenticated request, protocol parameters as
   well as any other parameter using the "oauth_" prefix SHALL be
   included in the request using one and only one of the following
   locations, listed in order of decreasing preference:

   1.  The HTTP "Authorization" header field as described in
       Section 3.5.1.

   2.  The HTTP request entity-body as described in Section 3.5.2.
```
