### PR TITLE
fixed OAuth1 authorization header

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -197,19 +197,20 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $bodyParams = null
     ) {
         $this->signature->setTokenSecret($token->getAccessTokenSecret());
-        $parameters = $this->getBasicAuthorizationHeaderInfo();
-        if (isset($parameters['oauth_callback'])) {
-            unset($parameters['oauth_callback']);
+        $authParameters = $this->getBasicAuthorizationHeaderInfo();
+        if (isset($authParameters['oauth_callback'])) {
+            unset($authParameters['oauth_callback']);
         }
 
-        $parameters = array_merge($parameters, array('oauth_token' => $token->getAccessToken()));
-        $parameters = (is_array($bodyParams)) ? array_merge($parameters, $bodyParams) : $parameters;
-        $parameters['oauth_signature'] = $this->signature->getSignature($uri, $parameters, $method);
+        $authParameters = array_merge($authParameters, array('oauth_token' => $token->getAccessToken()));
+
+        $signatureParams = (is_array($bodyParams)) ? array_merge($authParameters, $bodyParams) : $authParameters;
+        $authParameters['oauth_signature'] = $this->signature->getSignature($uri, $signatureParams, $method);
 
         $authorizationHeader = 'OAuth ';
         $delimiter = '';
 
-        foreach ($parameters as $key => $value) {
+        foreach ($authParameters as $key => $value) {
             $authorizationHeader .= $delimiter . rawurlencode($key) . '="' . rawurlencode($value) . '"';
             $delimiter = ', ';
         }


### PR DESCRIPTION
The commit c6e2d74 breaks the authorization in cases when `$bodyParams` is not empty. In such cases `$parameters` will get `oauth_verifier` key from `$bodyParams` (which is necessary only to make a signature) and puts it into the final authorization header, so authorization fails because of the wrong signature (example, try `FitBit` authorization).

These changes made better naming and fixed the authorization headers in such cases.
