### PR TITLE
Add public_profile scope to Facebook service

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -26,9 +26,11 @@ class Facebook extends AbstractService
      * @link https://developers.facebook.com/docs/reference/login/
      * @link https://developers.facebook.com/tools/explorer For a list of permissions use 'Get Access Token'
      */
-    // email scopes
+    // Default scope
+    const SCOPE_PUBLIC_PROFILE                = 'public_profile';
+    // Email scopes
     const SCOPE_EMAIL                         = 'email';
-    // extended permissions
+    // Extended permissions
     const SCOPE_READ_FRIENDLIST               = 'read_friendlists';
     const SCOPE_READ_INSIGHTS                 = 'read_insights';
     const SCOPE_READ_MAILBOX                  = 'read_mailbox';


### PR DESCRIPTION
According to https://developers.facebook.com/docs/facebook-login/permissions/v2.2 it is best practice to declare the `public_profile` scope:

> On the web, public_profile is implied with every request and isn't required, although the best practice is to declare it. On iOS and Android, you must manually request it as part of your login flow.