### PR TITLE
Fix Foursquare request duplicate baseApiUri.

### DIFF
--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -73,7 +73,7 @@ class Foursquare extends AbstractService
      */
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
-        $uri = new Uri($this->baseApiUri . $path);
+        $uri = $this->determineRequestUriFromPath($path, $this->baseApiUri);
         $uri->addToQuery('v', $this->apiVersionDate);
 
         return parent::request($uri, $method, $body, $extraHeaders);

--- a/tests/Unit/OAuth2/Service/FoursquareTest.php
+++ b/tests/Unit/OAuth2/Service/FoursquareTest.php
@@ -190,8 +190,36 @@ class FoursquareTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame(
-            'https://api.foursquare.com/v2/https://pieterhordijk.com/my/awesome/path?v=20130829',
+            'https://pieterhordijk.com/my/awesome/path?v=20130829',
             $service->request('https://pieterhordijk.com/my/awesome/path')->getAbsoluteUri()
+        );
+    }
+
+    /**
+     * @covers OAuth\OAuth2\Service\Foursquare::__construct
+     * @covers OAuth\OAuth2\Service\Foursquare::request
+     */
+    public function testRequestShortPath()
+    {
+        $client = $this->getMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
+        $client->expects($this->once())->method('retrieveResponse')->will($this->returnArgument(0));
+
+        $token = $this->getMock('\\OAuth\\OAuth2\\Token\\TokenInterface');
+        $token->expects($this->once())->method('getEndOfLife')->will($this->returnValue(TokenInterface::EOL_NEVER_EXPIRES));
+        $token->expects($this->once())->method('getAccessToken')->will($this->returnValue('foo'));
+
+        $storage = $this->getMock('\\OAuth\\Common\\Storage\\TokenStorageInterface');
+        $storage->expects($this->once())->method('retrieveAccessToken')->will($this->returnValue($token));
+
+        $service = new Foursquare(
+            $this->getMock('\\OAuth\\Common\\Consumer\\CredentialsInterface'),
+            $client,
+            $storage
+        );
+
+        $this->assertSame(
+            'https://api.foursquare.com/v2/my/awesome/path?v=20130829',
+            $service->request('my/awesome/path')->getAbsoluteUri()
         );
     }
 }


### PR DESCRIPTION
Hi!
I get an error when I use the Foursquare service with a full uri
Example:
$foursquareService->request('https://api.foursquare.com/v2/users/self');
It duplicate base uri like:
https://api.foursquare.com:443/v2/https://api.foursquare.com/v2/users/self

