### PR TITLE
Add support for OAuth1 PLAINTEXT signature method

### DIFF
--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -56,6 +56,9 @@ class Signature implements SignatureInterface
      */
     public function getSignature(UriInterface $uri, array $params, $method = 'POST')
     {
+        if ($this->algorithm == 'PLAINTEXT') // can be specified by extending service->getSignatureMethod()
+	        return $this->getSigningKey();
+
         parse_str($uri->getQuery(), $queryStringData);
 
         foreach (array_merge($queryStringData, $params) as $key => $value) {


### PR DESCRIPTION
This library currently supports only OAuth1 signature_method of HMAC-SHA1.
OAuth1 specification have simpler signature_method of PLAINTEXT with less processing complexity.
This is a very safe 2 line change.

My company uses this library, but because Signature is a private function in ServiceFactory::buildV1Service, I have to extend almost the whole ServiceFactory just to put this change in:)