### PR TITLE
Add new user_managed_groups Facebook permission

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -69,6 +69,7 @@ class Facebook extends AbstractService
     const SCOPE_USER_EVENTS                   = 'user_events';
     const SCOPE_FRIENDS_EVENTS                = 'friends_events';
     const SCOPE_USER_GROUPS                   = 'user_groups';
+    const SCOPE_USER_MANAGED_GROUPS           = 'user_managed_groups';
     const SCOPE_FRIENDS_GROUPS                = 'friends_groups';
     const SCOPE_USER_HOMETOWN                 = 'user_hometown';
     const SCOPE_FRIENDS_HOMETOWN              = 'friends_hometown';

--- a/src/OAuth/OAuth2/Service/Linkedin.php
+++ b/src/OAuth/OAuth2/Service/Linkedin.php
@@ -31,6 +31,7 @@ class Linkedin extends AbstractService
     const SCOPE_RW_COMPANY_ADMIN    = 'rw_company_admin';
     const SCOPE_RW_GROUPS           = 'rw_groups';
     const SCOPE_W_MESSAGES          = 'w_messages';
+    const SCOPE_W_SHARE             = 'w_share';
 
     public function __construct(
         CredentialsInterface $credentials,


### PR DESCRIPTION
Facebook recently announced a new user_managed_groups permission to allow apps to post to groups a user is a manager of. This proposed change just adds that scope to the Facebook service.