### PR TITLE
Facebook user_posts scope fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 composer.lock
 examples/init.php
 atlassian-ide-plugin.xml
+nbproject/

--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -55,6 +55,7 @@ class Facebook extends AbstractService
     const SCOPE_SMS                           = 'sms';
     const SCOPE_STATUS_UPDATE                 = 'status_update';
     // Extended Profile Properties
+    const SCOPE_USER_POSTS                    = 'user_posts';
     const SCOPE_USER_FRIENDS                  = 'user_friends';
     const SCOPE_USER_ABOUT                    = 'user_about_me';
     const SCOPE_FRIENDS_ABOUT                 = 'friends_about_me';


### PR DESCRIPTION
Added new user_posts scope due to API v2.3 breaking change:
https://developers.facebook.com/docs/apps/changelog#v2_3

Also added nbproject (NetBeans project config) to .gitignore, out of habit.  Let me know if that should be removed from the PR.