### PR TITLE
HTTP Response code message on TokenResponseException

### DIFF
--- a/src/OAuth/Common/Http/Client/StreamClient.php
+++ b/src/OAuth/Common/Http/Client/StreamClient.php
@@ -65,7 +65,7 @@ class StreamClient extends AbstractClient
         if (false === $response) {
             $lastError = error_get_last();
             if (is_null($lastError)) {
-                throw new TokenResponseException('Failed to request resource.');
+                throw new TokenResponseException('Failed to request resource. HTTP Code: '.((isset($http_response_header[0]))?$http_response_header[0]:'No response'));
             }
             throw new TokenResponseException($lastError['message']);
         }


### PR DESCRIPTION
I'm working with the Twitter client and received "Failed to request resource" for several reasons. With the HTTP code I'm able to know what is happening.

It also may be good to insert an argument into TokenResponseException allowing us to insert this code. But that's what I did to my project 