### PR TITLE
Add variable scopesDelimiter

### DIFF
--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -83,7 +83,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             )
         );
 
-        $parameters['scope'] = implode(' ', $this->scopes);
+        $parameters['scope'] = implode($this->getScopesDelimiter(), $this->scopes);
 
         if ($this->needsStateParameterInAuthUrl()) {
             if (!isset($parameters['state'])) {
@@ -348,5 +348,17 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     protected function getApiVersionString()
     {
         return !(empty($this->apiVersion)) ? "/".$this->apiVersion : "" ;
+    }
+
+    /**
+     * Returns delimiter to scopes in getAuthorizationUri
+     * For services that do not fully respect the Oauth's RFC,
+     * and use scopes with commas as delimiter
+     *
+     * @return string
+     */
+    protected function getScopesDelimiter()
+    {
+        return ' ';
     }
 }

--- a/src/OAuth/OAuth2/Service/Strava.php
+++ b/src/OAuth/OAuth2/Service/Strava.php
@@ -137,37 +137,11 @@ class Strava extends AbstractService
         $this->approvalPrompt = $prompt;
     }
 
-    // @todo remove this if we can define scopes delimiter in the service class
     /**
      * {@inheritdoc}
      */
-    public function getAuthorizationUri(array $additionalParameters = array())
+    protected function getScopesDelimiter()
     {
-        $parameters = array_merge(
-            $additionalParameters,
-            array(
-                'type'          => 'web_server',
-                'client_id'     => $this->credentials->getConsumerId(),
-                'redirect_uri'  => $this->credentials->getCallbackUrl(),
-                'response_type' => 'code',
-            )
-        );
-
-        $parameters['scope'] = implode(',', $this->scopes);
-
-        if ($this->needsStateParameterInAuthUrl()) {
-            if (!isset($parameters['state'])) {
-                $parameters['state'] = $this->generateAuthorizationState();
-            }
-            $this->storeAuthorizationState($parameters['state']);
-        }
-
-        // Build the url
-        $url = clone $this->getAuthorizationEndpoint();
-        foreach ($parameters as $key => $val) {
-            $url->addToQuery($key, $val);
-        }
-
-        return $url;
+        return ',';
     }
 }


### PR DESCRIPTION
Hi!

Some service like Strava, do not fully respect the Oauth's RFC, and use scopes with commas as delimiter.
What do you think about set a variable for defined the delimiter used in OAuth\OAuth2\Service\AbstractService getAuthorizationUri(), and overwrite it in the service class?

e.g. for comma
    protected $scopesDelimiter = ',';