### PR TITLE
Bugfix for facebook scope delimter

### DIFF
--- a/src/OAuth/ServiceFactory.php
+++ b/src/OAuth/ServiceFactory.php
@@ -117,7 +117,7 @@ class ServiceFactory
         foreach ($this->serviceBuilders as $version => $buildMethod) {
             $fullyQualifiedServiceName = $this->getFullyQualifiedServiceName($serviceName, $version);
 
-            if (class_exists($fullyQualifiedServiceName)) {
+            if (class_exists($fullyQualifiedServiceName, false)) {
                 return $this->$buildMethod(
                     $fullyQualifiedServiceName,
                     $credentials,

--- a/src/OAuth/ServiceFactory.php
+++ b/src/OAuth/ServiceFactory.php
@@ -117,7 +117,7 @@ class ServiceFactory
         foreach ($this->serviceBuilders as $version => $buildMethod) {
             $fullyQualifiedServiceName = $this->getFullyQualifiedServiceName($serviceName, $version);
 
-            if (class_exists($fullyQualifiedServiceName, false)) {
+            if (class_exists($fullyQualifiedServiceName)) {
                 return $this->$buildMethod(
                     $fullyQualifiedServiceName,
                     $credentials,


### PR DESCRIPTION
',’ instead of ' '