### PR TITLE
Change LinkedIn auth method to header

### DIFF
--- a/src/OAuth/OAuth2/Service/Linkedin.php
+++ b/src/OAuth/OAuth2/Service/Linkedin.php
@@ -68,7 +68,7 @@ class Linkedin extends AbstractService
      */
     protected function getAuthorizationMethod()
     {
-        return static::AUTHORIZATION_METHOD_QUERY_STRING_V2;
+        return static::AUTHORIZATION_METHOD_HEADER_BEARER;
     }
 
     /**

--- a/tests/Unit/OAuth2/Service/LinkedinTest.php
+++ b/tests/Unit/OAuth2/Service/LinkedinTest.php
@@ -94,7 +94,7 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
     public function testGetAuthorizationMethod()
     {
         $client = $this->getMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
-        $client->expects($this->once())->method('retrieveResponse')->will($this->returnArgument(0));
+        $client->expects($this->once())->method('retrieveResponse')->will($this->returnArgument(2));
 
         $token = $this->getMock('\\OAuth\\OAuth2\\Token\\TokenInterface');
         $token->expects($this->once())->method('getEndOfLife')->will($this->returnValue(TokenInterface::EOL_NEVER_EXPIRES));

--- a/tests/Unit/OAuth2/Service/LinkedinTest.php
+++ b/tests/Unit/OAuth2/Service/LinkedinTest.php
@@ -109,10 +109,9 @@ class LinkedinTest extends \PHPUnit_Framework_TestCase
             $storage
         );
 
-        $uri         = $service->request('https://pieterhordijk.com/my/awesome/path');
-        $absoluteUri = parse_url($uri->getAbsoluteUri());
-
-        $this->assertSame('oauth2_access_token=foo', $absoluteUri['query']);
+        $headers = $service->request('https://pieterhordijk.com/my/awesome/path');
+        $this->assertTrue(array_key_exists('Authorization', $headers));
+        $this->assertTrue(in_array('Bearer foo', $headers, true));
     }
 
     /**


### PR DESCRIPTION
LinkedIn is no longer accepting the access token in the query string, it is now receiving it via Auth Header. https://developer.linkedin.com/docs/oauth2 (Step 4) Tested this week in local project.