### PR TITLE
Bugfix for php 5.3

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -216,7 +216,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $signatureParams = (is_array($bodyParams)) ? array_merge($authParameters, $bodyParams) : $authParameters;
         $authParameters['oauth_signature'] = $this->signature->getSignature($uri, $signatureParams, $method);
 
-        if (isset($bodyParams['oauth_session_handle'])) {
+        if (is_array($bodyParams) && isset($bodyParams['oauth_session_handle'])) {
             $authParameters['oauth_session_handle'] = $bodyParams['oauth_session_handle'];
             unset($bodyParams['oauth_session_handle']);
         }

--- a/tests/Unit/OAuth1/Service/AbstractServiceTest.php
+++ b/tests/Unit/OAuth1/Service/AbstractServiceTest.php
@@ -212,4 +212,31 @@ class AbstractServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('response!', $service->request('/my/awesome/path'));
     }
+
+    /**
+     * This test only captures a regression in php 5.3.
+     *
+     * @covers OAuth\OAuth1\Service\AbstractService::request
+     */
+    public function testRequestNonArrayBody()
+    {
+        $client = $this->getMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
+        $client->expects($this->once())->method('retrieveResponse')->will($this->returnValue('response!'));
+
+        $token = $this->getMock('\\OAuth\\OAuth1\\Token\\TokenInterface');
+
+        $storage = $this->getMock('\\OAuth\\Common\\Storage\\TokenStorageInterface');
+        $storage->expects($this->any())->method('retrieveAccessToken')->will($this->returnValue($token));
+
+        $service = new Mock(
+            $this->getMock('\\OAuth\\Common\\Consumer\\CredentialsInterface'),
+            $client,
+            $storage,
+            $this->getMock('\\OAuth\\OAuth1\\Signature\\SignatureInterface'),
+            $this->getMock('\\OAuth\\Common\\Http\\Uri\\UriInterface')
+        );
+
+        $this->assertSame('response!', $service->request('/my/awesome/path', 'GET', 'A text body'));
+    }
+
 }


### PR DESCRIPTION
String index checking in php 5.3 permits string to integer casting, e.g. 

    $string = 'a string';
    echo $string['index']; // echos 'a'

This fix ensures the `$bodyParams` are an `array` before trying to extract the `oauth_session_handle`