### PR TITLE
Update Google Adwords Scope:  Trailing slash no longer supported

### DIFF
--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -49,7 +49,8 @@ class Google extends AbstractService
 
     // Adwords
     const SCOPE_ADSENSE                     = 'https://www.googleapis.com/auth/adsense';
-    const SCOPE_ADWORDS                     = 'https://www.googleapis.com/auth/adwords/';
+    const SCOPE_ADWORDS                     = 'https://www.googleapis.com/auth/adwords';
+    const SCOPE_ADWORDS_DEPRECATED          = 'https://www.googleapis.com/auth/adwords/'; //deprecated in v201406 API version
     const SCOPE_GAN                         = 'https://www.googleapis.com/auth/gan'; // google affiliate network...?
 
     //Doubleclick for Publishers


### PR DESCRIPTION
Trailing slash version was deprecated in API v201406

https://developers.google.com/adwords/api/docs/guides/authentication#scope

Left old scope to make sure nothing breaks even though it won't work anymore.