### PR TITLE
Session.php Destruct should not call session_write_close

### DIFF
--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -179,13 +179,6 @@ class Session implements TokenStorageInterface
         return $this;
     }
 
-    public function __destruct()
-    {
-        if ($this->startSession) {
-            session_write_close();
-        }
-    }
-
     /**
      * Determine if the session has started.
      * @url http://stackoverflow.com/a/18542272/1470961


### PR DESCRIPTION
This relates to the following issue:
https://github.com/Lusitanian/PHPoAuthLib/issues/285