### PR TITLE
Proper API Version handling for FB's URLs

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -169,7 +169,7 @@ class Facebook extends AbstractService
 
         $token = new StdOAuth2Token();
         $token->setAccessToken($data['access_token']);
-        
+
         if (isset($data['expires'])) {
             $token->setLifeTime($data['expires']);
         }
@@ -196,6 +196,14 @@ class Facebook extends AbstractService
         $baseUrl = self::WWW_URL .$this->getApiVersionString(). '/dialog/' . $dialogPath;
         $query = http_build_query($parameters);
         return new Uri($baseUrl . '?' . $query);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getApiVersionString()
+    {
+        return empty($this->apiVersion) ? '' : '/v' . $this->apiVersion;
     }
 
     /**


### PR DESCRIPTION
Facebook prepends versions with a 'v' on all URLs.
Closes #389, #346 and #287.