### PR TITLE
Request Flickr API with multiple arguments

### DIFF
--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -100,34 +100,65 @@ class Flickr extends AbstractService
 
     public function requestRest($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
-        return $this->request($path, $method, $body, $extraHeaders);
+        return $this->requestAPI($path, $method, $body, $extraHeaders);
     }
 
     public function requestXmlrpc($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $this->format = 'xmlrpc';
 
-        return $this->request($path, $method, $body, $extraHeaders);
+        return $this->requestAPI($path, $method, $body, $extraHeaders);
     }
 
     public function requestSoap($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $this->format = 'soap';
 
-        return $this->request($path, $method, $body, $extraHeaders);
+        return $this->requestAPI($path, $method, $body, $extraHeaders);
     }
 
     public function requestJson($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $this->format = 'json';
 
-        return $this->request($path, $method, $body, $extraHeaders);
+        return $this->requestAPI($path, $method, $body, $extraHeaders);
     }
 
     public function requestPhp($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $this->format = 'php_serial';
 
-        return $this->request($path, $method, $body, $extraHeaders);
+        return $this->requestAPI($path, $method, $body, $extraHeaders);
+    }
+    
+    public function requestAPI(array $path = array(), $method = 'GET', $body = null, array $extraHeaders = array())
+    {
+        $uri = $this->determineRequestUriFromPath('/', $this->baseApiUri);
+        $uri->addToQuery('method', $path['method']);
+        // Revision 2
+        unset($path['method']);
+        if(!empty($path)) {
+
+            foreach ($path as $key => $value) {
+                $uri->addToQuery($key, $value);
+            }
+        }
+
+        if (!empty($this->format)) {
+            $uri->addToQuery('format', $this->format);
+
+            if ($this->format === 'json') {
+                $uri->addToQuery('nojsoncallback', 1);
+            }
+        }
+
+        $token = $this->storage->retrieveAccessToken($this->service());
+        $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);
+        $authorizationHeader = array(
+            'Authorization' => $this->buildAuthorizationHeaderForAPIRequest($method, $uri, $token, $body)
+        );
+        $headers = array_merge($authorizationHeader, $extraHeaders);
+
+        return $this->httpClient->retrieveResponse($uri, $body, $headers, $method);
     }
 }


### PR DESCRIPTION
Added new function requestAPI() in Flickr Service which can be used to fetch Flickr API with multiple parameters like 

    ['per_page' = '10', 'user_id' => '232423@NO1']    

Please check it from your side.