### PR TITLE
fix AbstractToken endOfLife initialization

### DIFF
--- a/src/OAuth/Common/Token/AbstractToken.php
+++ b/src/OAuth/Common/Token/AbstractToken.php
@@ -30,14 +30,14 @@ abstract class AbstractToken implements TokenInterface
     /**
      * @param string $accessToken
      * @param string $refreshToken
-     * @param int    $lifetime
+     * @param int    $endOfLife
      * @param array  $extraParams
      */
-    public function __construct($accessToken = null, $refreshToken = null, $lifetime = null, $extraParams = array())
+    public function __construct($accessToken = null, $refreshToken = null, $endOfLife = null, $extraParams = array())
     {
         $this->accessToken = $accessToken;
         $this->refreshToken = $refreshToken;
-        $this->setLifetime($lifetime);
+        $this->setEndOfLife($endOfLife);
         $this->extraParams = $extraParams;
     }
 


### PR DESCRIPTION
The timestamp loaded from token storage is an absolute time, not a number of seconds from now.  

I checked a hand full of services and they all set the lifetime as a relative number of seconds correctly using setLifetime().  However, when loading from token storage, it uses the constructor and passes in the absolute time the token expires, not a relative time, so it should be set with setEndOfLife().

