### PR TITLE
bubble this up for a way to check for valid credentials

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -138,7 +138,12 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         );
         $headers = array_merge($authorizationHeader, $extraHeaders);
 
-        return $this->httpClient->retrieveResponse($uri, $body, $headers, $method);
+        try {
+          $response = $this->httpClient->retrieveResponse($uri, $body, $headers, $method);
+        } catch(TokenResponseException $e) {
+          throw $e;
+        }
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Currently if you make a request with invalid credentials you end up with an uncaught exception. Let's handle that. Could also just return false? Up for suggestions, but due to #463 something has to happen here or there's no way to verify that your access token is truly an access token, not a request token that was stored as both