### PR TITLE
set CURLOPT_FAILONERROR on true

### DIFF
--- a/src/OAuth/Common/Http/Client/CurlClient.php
+++ b/src/OAuth/Common/Http/Client/CurlClient.php
@@ -113,6 +113,7 @@ class CurlClient extends AbstractClient
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $extraHeaders);
         curl_setopt($ch, CURLOPT_USERAGENT, $this->userAgent);
+        curl_setopt($ch, CURLOPT_FAILONERROR, true);
 
         foreach ($this->parameters as $key => $value) {
             curl_setopt($ch, $key, $value);


### PR DESCRIPTION
CURLOPT_FAILONERROR should be set true, to trigger http errors.
