### PR TITLE
Seperate request and access token based requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 PHPoAuthLib
 ===========
-**NOTE: I'm looking for someone who could help to maintain this package alongside me, just because I don't have a ton of time to devote to it. However, I'm still going to keep trying to pay attention to PRs, etc.**
-
 PHPoAuthLib provides oAuth support in PHP 5.3+ and is very easy to integrate with any project which requires an oAuth client.
 
 [![Build Status](https://travis-ci.org/Lusitanian/PHPoAuthLib.png?branch=master)](https://travis-ci.org/Lusitanian/PHPoAuthLib)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 PHPoAuthLib
 ===========
+**NOTE: I'm looking for someone who could help to maintain this package alongside me, just because I don't have a ton of time to devote to it. However, I'm still going to keep trying to pay attention to PRs, etc.**
+
 PHPoAuthLib provides oAuth support in PHP 5.3+ and is very easy to integrate with any project which requires an oAuth client.
 
 [![Build Status](https://travis-ci.org/Lusitanian/PHPoAuthLib.png?branch=master)](https://travis-ci.org/Lusitanian/PHPoAuthLib)

--- a/src/OAuth/OAuth1/Service/BitBucket.php
+++ b/src/OAuth/OAuth1/Service/BitBucket.php
@@ -50,47 +50,5 @@ class BitBucket extends AbstractService
     {
         return new Uri('https://bitbucket.org/!api/1.0/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -60,50 +60,7 @@ class Etsy extends AbstractService
     {
         return new Uri($this->baseApiUri . 'oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
-
+    
     /**
      * Set the scopes for permissions
      * @see https://www.etsy.com/developers/documentation/getting_started/oauth#section_permission_scopes

--- a/src/OAuth/OAuth1/Service/FitBit.php
+++ b/src/OAuth/OAuth1/Service/FitBit.php
@@ -50,47 +50,5 @@ class FitBit extends AbstractService
     {
         return new Uri('https://api.fitbit.com/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/FiveHundredPx.php
+++ b/src/OAuth/OAuth1/Service/FiveHundredPx.php
@@ -70,51 +70,5 @@ class FiveHundredPx extends AbstractService
     {
         return new Uri('https://api.500px.com/v1/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed'])
-            || $data['oauth_callback_confirmed'] !== 'true'
-        ) {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException(
-                'Error in retrieving token: "' . $data['error'] . '"'
-            );
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -43,38 +43,6 @@ class Flickr extends AbstractService
         return new Uri('https://www.flickr.com/services/oauth/access_token');
     }
 
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] != 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-        if ($data === null || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
-
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $uri = $this->determineRequestUriFromPath('/', $this->baseApiUri);

--- a/src/OAuth/OAuth1/Service/QuickBooks.php
+++ b/src/OAuth/OAuth1/Service/QuickBooks.php
@@ -61,51 +61,6 @@ class QuickBooks extends AbstractService
     }
 
     /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed'])
-            || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            $message = 'Error in retrieving token: "' . $data['error'] . '"';
-            throw new TokenResponseException($message);
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function request(

--- a/src/OAuth/OAuth1/Service/Redmine.php
+++ b/src/OAuth/OAuth1/Service/Redmine.php
@@ -50,47 +50,5 @@ class Redmine extends AbstractService
     {
         return new Uri($this->baseApiUri->getAbsoluteUri() . '/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/ScoopIt.php
+++ b/src/OAuth/OAuth1/Service/ScoopIt.php
@@ -50,47 +50,5 @@ class ScoopIt extends AbstractService
     {
         return new Uri('https://www.scoop.it/oauth/access');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Tumblr.php
+++ b/src/OAuth/OAuth1/Service/Tumblr.php
@@ -50,47 +50,5 @@ class Tumblr extends AbstractService
     {
         return new Uri('https://www.tumblr.com/oauth/access_token');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
+    
 }

--- a/src/OAuth/OAuth1/Service/Twitter.php
+++ b/src/OAuth/OAuth1/Service/Twitter.php
@@ -76,48 +76,4 @@ class Twitter extends AbstractService
         return new Uri('https://api.twitter.com/oauth/access_token');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response: ' . $responseBody);
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        } elseif (!isset($data["oauth_token"]) || !isset($data["oauth_token_secret"])) {
-            throw new TokenResponseException('Invalid response. OAuth Token data not set: ' . $responseBody);
-        }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
-    }
 }

--- a/src/OAuth/OAuth1/Service/Xing.php
+++ b/src/OAuth/OAuth1/Service/Xing.php
@@ -50,48 +50,22 @@ class Xing extends AbstractService
     {
         return new Uri('https://api.xing.com/v1/request_token');
     }
-
+    
     /**
      * {@inheritdoc}
      */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function parseAccessTokenResponse($responseBody)
+    protected function validateTokenResponse($responseBody)
     {
         parse_str($responseBody, $data);
         $errors = json_decode($responseBody);
-
+        
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
         } elseif ($errors) {
             throw new TokenResponseException('Error in retrieving token: "' . $errors->error_name . '"');
         }
-
-        $token = new StdOAuth1Token();
-
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
-        $token->setAccessToken($data['oauth_token']);
-        $token->setAccessTokenSecret($data['oauth_token_secret']);
-
-        $token->setEndOfLife(StdOAuth1Token::EOL_NEVER_EXPIRES);
-        unset($data['oauth_token'], $data['oauth_token_secret']);
-        $token->setExtraParams($data);
-
-        return $token;
+        
+        return $data;
     }
+    
 }

--- a/src/OAuth/OAuth1/Service/Yahoo.php
+++ b/src/OAuth/OAuth1/Service/Yahoo.php
@@ -84,36 +84,12 @@ class Yahoo extends AbstractService
     /**
      * {@inheritdoc}
      */
-    protected function parseRequestTokenResponse($responseBody)
-    {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (!isset($data['oauth_callback_confirmed']) || $data['oauth_callback_confirmed'] !== 'true') {
-            throw new TokenResponseException('Error in retrieving token.');
-        }
-
-        return $this->parseAccessTokenResponse($responseBody);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function parseAccessTokenResponse($responseBody)
     {
-        parse_str($responseBody, $data);
-
-        if (null === $data || !is_array($data)) {
-            throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
-        }
-
+        $data = $this->validateTokenResponse($responseBody);
+        
         $token = new StdOAuth1Token();
 
-        $token->setRequestToken($data['oauth_token']);
-        $token->setRequestTokenSecret($data['oauth_token_secret']);
         $token->setAccessToken($data['oauth_token']);
         $token->setAccessTokenSecret($data['oauth_token_secret']);
 


### PR DESCRIPTION
I have noticed that the storages won't throw a TokenNotFoundException if there is no access token although a request token. I enabled this behaviour and refactored the methods that parse the access token and request token responses.