### PR TITLE
Changed Bitrix24 authorization method

### DIFF
--- a/src/OAuth/OAuth2/Service/Bitrix24.php
+++ b/src/OAuth/OAuth2/Service/Bitrix24.php
@@ -42,6 +42,14 @@ class Bitrix24 extends AbstractService
     /**
      * {@inheritdoc}
      */
+    protected function getAuthorizationMethod()
+    {
+        return static::AUTHORIZATION_METHOD_QUERY_STRING_V4;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function requestAccessToken($code, $state = null)
     {
         if (null !== $state) {


### PR DESCRIPTION
Now Bitrix24 API uses AUTHORIZATION_METHOD_QUERY_STRING_V4