### PR TITLE
Compatibility with facebook api version > 2

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -158,8 +158,12 @@ class Facebook extends AbstractService
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        // Facebook gives us a query string ... Oh wait. JSON is too simple, understand ?
-        parse_str($responseBody, $data);
+        $data = @json_decode($responseBody, true);
+
+        // Facebook gives us a query string on old api (v2.0)
+        if (!$data) {
+            parse_str($responseBody, $data);
+        }
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');


### PR DESCRIPTION
Facebook 2.0 version is end of life, I received this message on dev console : XX has been making recent API calls to Graph API v2.0, which will reach the end of the 2-year deprecation window on Monday, August 8, 2016. Please migrate all calls to v2.1 or higher in order to avoid potential broken experiences.

Access Token in later version is send as json, this patch allow to be compatible with old & current version