### PR TITLE
Added signature token secret for requestRequestToken

### DIFF
--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -46,6 +46,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      */
     public function requestRequestToken()
     {
+        $this->signature->setTokenSecret(null);
+        
         $authorizationHeader = array('Authorization' => $this->buildAuthorizationHeaderForTokenRequest());
         $headers = array_merge($authorizationHeader, $this->getExtraOAuthHeaders());
 


### PR DESCRIPTION
During a request the signature token secret is set with an value unlike null.
The problem is that you can't start the authorization process again( -> requestRequestToken())
because it'll fail due to the false signature token secret (should be null).

If you stored the the access token and secret for a longer time,
this behaviour makes it impossible to react to failed request with expired or changed access tokens.

This change makes it possible.