### PR TITLE
Set scopes if not set already

### DIFF
--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -361,4 +361,27 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     {
         return ' ';
     }
+
+    /**
+     * Set Scopes If not defined already
+     *
+     * @param $scopes
+     * @return $this
+     */
+    public function setScopes($scopes)
+    {
+        $this->scopes = $scopes;
+
+        return $this;
+    }
+
+    /**
+     * Get Scopes set for the service
+     *
+     * @return array
+     */
+    public function getScopes()
+    {
+        return $this->scopes;
+    }
 }


### PR DESCRIPTION
It is useful when common implementation for all service but for service scope available to set and some service not. So in that case you can set the scope using the service object. No need to do extra checks before passing scopes into createService method.

I have integrated [PHPoAuthLib into Cygnite framework](https://github.com/cygnite/framework/blob/master/src/Cygnite/Services/SocialOAuth/Providers/SocialAuthServiceProvider.php).