### PR TITLE
Multiple accounts per Service

### DIFF
--- a/src/OAuth/Common/Service/AbstractService.php
+++ b/src/OAuth/Common/Service/AbstractService.php
@@ -2,6 +2,7 @@
 
 namespace OAuth\Common\Service;
 
+use OAuth\Common\Consumer\Credentials;
 use OAuth\Common\Consumer\CredentialsInterface;
 use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Http\Uri\Uri;
@@ -23,19 +24,26 @@ abstract class AbstractService implements ServiceInterface
     /** @var TokenStorageInterface */
     protected $storage;
 
+    /** @var null|string */
+    protected $account = null;
+
     /**
      * @param CredentialsInterface  $credentials
      * @param ClientInterface       $httpClient
      * @param TokenStorageInterface $storage
+     * @param string                $account
+     *
      */
     public function __construct(
         CredentialsInterface $credentials,
         ClientInterface $httpClient,
-        TokenStorageInterface $storage
+        TokenStorageInterface $storage,
+        $account = null
     ) {
         $this->credentials = $credentials;
         $this->httpClient = $httpClient;
         $this->storage = $storage;
+        $this->account = $account;
     }
 
     /**
@@ -96,5 +104,13 @@ abstract class AbstractService implements ServiceInterface
         $classname = get_class($this);
 
         return preg_replace('/^.*\\\\/', '', $classname);
+    }
+
+    /**
+     * @return null|string
+     */
+    public function account()
+    {
+        return $this->account;
     }
 }

--- a/src/OAuth/Common/Storage/Memory.php
+++ b/src/OAuth/Common/Storage/Memory.php
@@ -30,10 +30,10 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAccessToken($service)
+    public function retrieveAccessToken($service, $account = null)
     {
-        if ($this->hasAccessToken($service)) {
-            return $this->tokens[$service];
+        if ($this->hasAccessToken($service, $account)) {
+            return $this->tokens[$service.$account];
         }
 
         throw new TokenNotFoundException('Token not stored');
@@ -42,9 +42,9 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, TokenInterface $token)
+    public function storeAccessToken($service, $account = null, TokenInterface $token)
     {
-        $this->tokens[$service] = $token;
+        $this->tokens[$service.$account] = $token;
 
         // allow chaining
         return $this;
@@ -53,18 +53,18 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAccessToken($service)
+    public function hasAccessToken($service, $account = null)
     {
-        return isset($this->tokens[$service]) && $this->tokens[$service] instanceof TokenInterface;
+        return isset($this->tokens[$service.$account]) && $this->tokens[$service.$account] instanceof TokenInterface;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearToken($service)
+    public function clearToken($service, $account = null)
     {
-        if (array_key_exists($service, $this->tokens)) {
-            unset($this->tokens[$service]);
+        if (array_key_exists($service.$account, $this->tokens)) {
+            unset($this->tokens[$service.$account]);
         }
 
         // allow chaining
@@ -85,10 +85,10 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAuthorizationState($service)
+    public function retrieveAuthorizationState($service, $account = null)
     {
-        if ($this->hasAuthorizationState($service)) {
-            return $this->states[$service];
+        if ($this->hasAuthorizationState($service, $account)) {
+            return $this->states[$service.$account];
         }
 
         throw new AuthorizationStateNotFoundException('State not stored');
@@ -97,9 +97,9 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $state)
+    public function storeAuthorizationState($service, $account = null, $state)
     {
-        $this->states[$service] = $state;
+        $this->states[$service.$account] = $state;
 
         // allow chaining
         return $this;
@@ -108,18 +108,18 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAuthorizationState($service)
+    public function hasAuthorizationState($service, $account = null)
     {
-        return isset($this->states[$service]) && null !== $this->states[$service];
+        return isset($this->states[$service.$account]) && null !== $this->states[$service.$account];
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearAuthorizationState($service)
+    public function clearAuthorizationState($service, $account = null)
     {
-        if (array_key_exists($service, $this->states)) {
-            unset($this->states[$service]);
+        if (array_key_exists($service.$account, $this->states)) {
+            unset($this->states[$service.$account]);
         }
 
         // allow chaining

--- a/src/OAuth/Common/Storage/Memory.php
+++ b/src/OAuth/Common/Storage/Memory.php
@@ -42,7 +42,7 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, $account = null, TokenInterface $token)
+    public function storeAccessToken($service, TokenInterface $token, $account = null)
     {
         $this->tokens[$service.$account] = $token;
 
@@ -97,7 +97,7 @@ class Memory implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $account = null, $state)
+    public function storeAuthorizationState($service, $state, $account = null)
     {
         $this->states[$service.$account] = $state;
 

--- a/src/OAuth/Common/Storage/Redis.php
+++ b/src/OAuth/Common/Storage/Redis.php
@@ -69,7 +69,7 @@ class Redis implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, $account = null, TokenInterface $token)
+    public function storeAccessToken($service, TokenInterface $token, $account = null)
     {
         // (over)write the token
         $this->redis->hset($this->key, $service.$account, serialize($token));
@@ -151,7 +151,7 @@ class Redis implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $account = null, $state)
+    public function storeAuthorizationState($service, $state, $account = null)
     {
         // (over)write the token
         $this->redis->hset($this->stateKey, $service.$account, $state);

--- a/src/OAuth/Common/Storage/Redis.php
+++ b/src/OAuth/Common/Storage/Redis.php
@@ -51,29 +51,29 @@ class Redis implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAccessToken($service)
+    public function retrieveAccessToken($service, $account = null)
     {
-        if (!$this->hasAccessToken($service)) {
+        if (!$this->hasAccessToken($service, $account)) {
             throw new TokenNotFoundException('Token not found in redis');
         }
 
-        if (isset($this->cachedTokens[$service])) {
-            return $this->cachedTokens[$service];
+        if (isset($this->cachedTokens[$service.$account])) {
+            return $this->cachedTokens[$service.$account];
         }
 
-        $val = $this->redis->hget($this->key, $service);
+        $val = $this->redis->hget($this->key, $service.$account);
 
-        return $this->cachedTokens[$service] = unserialize($val);
+        return $this->cachedTokens[$service.$account] = unserialize($val);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, TokenInterface $token)
+    public function storeAccessToken($service, $account = null, TokenInterface $token)
     {
         // (over)write the token
-        $this->redis->hset($this->key, $service, serialize($token));
-        $this->cachedTokens[$service] = $token;
+        $this->redis->hset($this->key, $service.$account, serialize($token));
+        $this->cachedTokens[$service.$account] = $token;
 
         // allow chaining
         return $this;
@@ -82,24 +82,24 @@ class Redis implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAccessToken($service)
+    public function hasAccessToken($service, $account = null)
     {
-        if (isset($this->cachedTokens[$service])
-            && $this->cachedTokens[$service] instanceof TokenInterface
+        if (isset($this->cachedTokens[$service.$account])
+            && $this->cachedTokens[$service.$account] instanceof TokenInterface
         ) {
             return true;
         }
 
-        return $this->redis->hexists($this->key, $service);
+        return $this->redis->hexists($this->key, $service.$account);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearToken($service)
+    public function clearToken($service, $account = null)
     {
-        $this->redis->hdel($this->key, $service);
-        unset($this->cachedTokens[$service]);
+        $this->redis->hdel($this->key, $service.$account);
+        unset($this->cachedTokens[$service.$account]);
 
         // allow chaining
         return $this;
@@ -133,29 +133,29 @@ class Redis implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAuthorizationState($service)
+    public function retrieveAuthorizationState($service, $account = null)
     {
-        if (!$this->hasAuthorizationState($service)) {
+        if (!$this->hasAuthorizationState($service, $account)) {
             throw new AuthorizationStateNotFoundException('State not found in redis');
         }
 
-        if (isset($this->cachedStates[$service])) {
-            return $this->cachedStates[$service];
+        if (isset($this->cachedStates[$service.$account])) {
+            return $this->cachedStates[$service.$account];
         }
 
-        $val = $this->redis->hget($this->stateKey, $service);
+        $val = $this->redis->hget($this->stateKey, $service.$account);
 
-        return $this->cachedStates[$service] = $val;
+        return $this->cachedStates[$service.$account] = $val;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $state)
+    public function storeAuthorizationState($service, $account = null, $state)
     {
         // (over)write the token
-        $this->redis->hset($this->stateKey, $service, $state);
-        $this->cachedStates[$service] = $state;
+        $this->redis->hset($this->stateKey, $service.$account, $state);
+        $this->cachedStates[$service.$account] = $state;
 
         // allow chaining
         return $this;
@@ -164,24 +164,24 @@ class Redis implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAuthorizationState($service)
+    public function hasAuthorizationState($service, $account = null)
     {
-        if (isset($this->cachedStates[$service])
-            && null !== $this->cachedStates[$service]
+        if (isset($this->cachedStates[$service.$account])
+            && null !== $this->cachedStates[$service.$account]
         ) {
             return true;
         }
 
-        return $this->redis->hexists($this->stateKey, $service);
+        return $this->redis->hexists($this->stateKey, $service.$account);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearAuthorizationState($service)
+    public function clearAuthorizationState($service, $account = null)
     {
-        $this->redis->hdel($this->stateKey, $service);
-        unset($this->cachedStates[$service]);
+        $this->redis->hdel($this->stateKey, $service.$account);
+        unset($this->cachedStates[$service.$account]);
 
         // allow chaining
         return $this;

--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -66,7 +66,7 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, $account = null, TokenInterface $token)
+    public function storeAccessToken($service, TokenInterface $token, $account = null)
     {
         $serializedToken = serialize($token);
 
@@ -119,7 +119,7 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $account = null, $state)
+    public function storeAuthorizationState($service, $state, $account = null)
     {
         if (isset($_SESSION[$this->stateVariableName])
             && is_array($_SESSION[$this->stateVariableName])

--- a/src/OAuth/Common/Storage/Session.php
+++ b/src/OAuth/Common/Storage/Session.php
@@ -54,10 +54,10 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAccessToken($service)
+    public function retrieveAccessToken($service, $account = null)
     {
-        if ($this->hasAccessToken($service)) {
-            return unserialize($_SESSION[$this->sessionVariableName][$service]);
+        if ($this->hasAccessToken($service, $account)) {
+            return unserialize($_SESSION[$this->sessionVariableName][$service.$account]);
         }
 
         throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
@@ -66,17 +66,17 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, TokenInterface $token)
+    public function storeAccessToken($service, $account = null, TokenInterface $token)
     {
         $serializedToken = serialize($token);
 
         if (isset($_SESSION[$this->sessionVariableName])
             && is_array($_SESSION[$this->sessionVariableName])
         ) {
-            $_SESSION[$this->sessionVariableName][$service] = $serializedToken;
+            $_SESSION[$this->sessionVariableName][$service.$account] = $serializedToken;
         } else {
             $_SESSION[$this->sessionVariableName] = array(
-                $service => $serializedToken,
+                $service.$account => $serializedToken,
             );
         }
 
@@ -87,18 +87,18 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAccessToken($service)
+    public function hasAccessToken($service, $account = null)
     {
-        return isset($_SESSION[$this->sessionVariableName], $_SESSION[$this->sessionVariableName][$service]);
+        return isset($_SESSION[$this->sessionVariableName], $_SESSION[$this->sessionVariableName][$service.$account]);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearToken($service)
+    public function clearToken($service, $account = null)
     {
-        if (array_key_exists($service, $_SESSION[$this->sessionVariableName])) {
-            unset($_SESSION[$this->sessionVariableName][$service]);
+        if (array_key_exists($service.$account, $_SESSION[$this->sessionVariableName])) {
+            unset($_SESSION[$this->sessionVariableName][$service.$account]);
         }
 
         // allow chaining
@@ -119,15 +119,15 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $state)
+    public function storeAuthorizationState($service, $account = null, $state)
     {
         if (isset($_SESSION[$this->stateVariableName])
             && is_array($_SESSION[$this->stateVariableName])
         ) {
-            $_SESSION[$this->stateVariableName][$service] = $state;
+            $_SESSION[$this->stateVariableName][$service.$account] = $state;
         } else {
             $_SESSION[$this->stateVariableName] = array(
-                $service => $state,
+                $service.$account => $state,
             );
         }
 
@@ -138,18 +138,18 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAuthorizationState($service)
+    public function hasAuthorizationState($service, $account = null)
     {
-        return isset($_SESSION[$this->stateVariableName], $_SESSION[$this->stateVariableName][$service]);
+        return isset($_SESSION[$this->stateVariableName], $_SESSION[$this->stateVariableName][$service.$account]);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function retrieveAuthorizationState($service)
+    public function retrieveAuthorizationState($service, $account = null)
     {
-        if ($this->hasAuthorizationState($service)) {
-            return $_SESSION[$this->stateVariableName][$service];
+        if ($this->hasAuthorizationState($service, $account)) {
+            return $_SESSION[$this->stateVariableName][$service.$account];
         }
 
         throw new AuthorizationStateNotFoundException('State not found in session, are you sure you stored it?');
@@ -158,10 +158,10 @@ class Session implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function clearAuthorizationState($service)
+    public function clearAuthorizationState($service, $account = null)
     {
-        if (array_key_exists($service, $_SESSION[$this->stateVariableName])) {
-            unset($_SESSION[$this->stateVariableName][$service]);
+        if (array_key_exists($service.$account, $_SESSION[$this->stateVariableName])) {
+            unset($_SESSION[$this->stateVariableName][$service.$account]);
         }
 
         // allow chaining

--- a/src/OAuth/Common/Storage/SymfonySession.php
+++ b/src/OAuth/Common/Storage/SymfonySession.php
@@ -49,7 +49,7 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, $account = null, TokenInterface $token)
+    public function storeAccessToken($service, TokenInterface $token, $account = null)
     {
         // get previously saved tokens
         $tokens = $this->session->get($this->sessionVariableName);
@@ -129,7 +129,7 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $account = null, $state)
+    public function storeAuthorizationState($service, $state, $account = null)
     {
         // get previously saved tokens
         $states = $this->session->get($this->stateVariableName);

--- a/src/OAuth/Common/Storage/SymfonySession.php
+++ b/src/OAuth/Common/Storage/SymfonySession.php
@@ -33,14 +33,14 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAccessToken($service)
+    public function retrieveAccessToken($service, $account = null)
     {
-        if ($this->hasAccessToken($service)) {
+        if ($this->hasAccessToken($service, $account)) {
             // get from session
             $tokens = $this->session->get($this->sessionVariableName);
 
             // one item
-            return $tokens[$service];
+            return $tokens[$service.$account];
         }
 
         throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
@@ -49,7 +49,7 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAccessToken($service, TokenInterface $token)
+    public function storeAccessToken($service, $account = null, TokenInterface $token)
     {
         // get previously saved tokens
         $tokens = $this->session->get($this->sessionVariableName);
@@ -58,7 +58,7 @@ class SymfonySession implements TokenStorageInterface
             $tokens = array();
         }
 
-        $tokens[$service] = $token;
+        $tokens[$service.$account] = $token;
 
         // save
         $this->session->set($this->sessionVariableName, $tokens);
@@ -70,26 +70,26 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAccessToken($service)
+    public function hasAccessToken($service, $account = null)
     {
         // get from session
         $tokens = $this->session->get($this->sessionVariableName);
 
         return is_array($tokens)
-            && isset($tokens[$service])
-            && $tokens[$service] instanceof TokenInterface;
+            && isset($tokens[$service.$account])
+            && $tokens[$service.$account] instanceof TokenInterface;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearToken($service)
+    public function clearToken($service, $account = null)
     {
         // get previously saved tokens
         $tokens = $this->session->get($this->sessionVariableName);
 
-        if (is_array($tokens) && array_key_exists($service, $tokens)) {
-            unset($tokens[$service]);
+        if (is_array($tokens) && array_key_exists($service.$account, $tokens)) {
+            unset($tokens[$service.$account]);
 
             // Replace the stored tokens array
             $this->session->set($this->sessionVariableName, $tokens);
@@ -113,14 +113,14 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function retrieveAuthorizationState($service)
+    public function retrieveAuthorizationState($service, $account = null)
     {
-        if ($this->hasAuthorizationState($service)) {
+        if ($this->hasAuthorizationState($service, $account)) {
             // get from session
             $states = $this->session->get($this->stateVariableName);
 
             // one item
-            return $states[$service];
+            return $states[$service.$account];
         }
 
         throw new AuthorizationStateNotFoundException('State not found in session, are you sure you stored it?');
@@ -129,7 +129,7 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function storeAuthorizationState($service, $state)
+    public function storeAuthorizationState($service, $account = null, $state)
     {
         // get previously saved tokens
         $states = $this->session->get($this->stateVariableName);
@@ -138,7 +138,7 @@ class SymfonySession implements TokenStorageInterface
             $states = array();
         }
 
-        $states[$service] = $state;
+        $states[$service.$account] = $state;
 
         // save
         $this->session->set($this->stateVariableName, $states);
@@ -150,26 +150,26 @@ class SymfonySession implements TokenStorageInterface
     /**
      * {@inheritDoc}
      */
-    public function hasAuthorizationState($service)
+    public function hasAuthorizationState($service, $account = null)
     {
         // get from session
         $states = $this->session->get($this->stateVariableName);
 
         return is_array($states)
-        && isset($states[$service])
-        && null !== $states[$service];
+        && isset($states[$service.$account])
+        && null !== $states[$service.$account];
     }
 
     /**
      * {@inheritDoc}
      */
-    public function clearAuthorizationState($service)
+    public function clearAuthorizationState($service, $account = null)
     {
         // get previously saved tokens
         $states = $this->session->get($this->stateVariableName);
 
-        if (is_array($states) && array_key_exists($service, $states)) {
-            unset($states[$service]);
+        if (is_array($states) && array_key_exists($service.$account, $states)) {
+            unset($states[$service.$account]);
 
             // Replace the stored tokens array
             $this->session->set($this->stateVariableName, $states);

--- a/src/OAuth/Common/Storage/TokenStorageInterface.php
+++ b/src/OAuth/Common/Storage/TokenStorageInterface.php
@@ -12,36 +12,40 @@ interface TokenStorageInterface
 {
     /**
      * @param string $service
+     * @param string $account
      *
      * @return TokenInterface
      *
      * @throws TokenNotFoundException
      */
-    public function retrieveAccessToken($service);
+    public function retrieveAccessToken($service, $account = null);
 
     /**
      * @param string         $service
+     * @param string $account
      * @param TokenInterface $token
      *
      * @return TokenStorageInterface
      */
-    public function storeAccessToken($service, TokenInterface $token);
+    public function storeAccessToken($service, $account = null, TokenInterface $token);
 
     /**
      * @param string $service
+     * @param string $account
      *
      * @return bool
      */
-    public function hasAccessToken($service);
+    public function hasAccessToken($service, $account = null);
 
     /**
      * Delete the users token. Aka, log out.
      *
      * @param string $service
+     * @param string $account
      *
      * @return TokenStorageInterface
      */
-    public function clearToken($service);
+    public function clearToken($service, $account = null);
 
     /**
      * Delete *ALL* user tokens. Use with care. Most of the time you will likely
@@ -55,38 +59,42 @@ interface TokenStorageInterface
      * Store the authorization state related to a given service
      *
      * @param string $service
+     * @param string $account
      * @param string $state
      *
      * @return TokenStorageInterface
      */
-    public function storeAuthorizationState($service, $state);
+    public function storeAuthorizationState($service, $account = null, $state);
 
     /**
      * Check if an authorization state for a given service exists
      *
      * @param string $service
+     * @param string $account
      *
      * @return bool
      */
-    public function hasAuthorizationState($service);
+    public function hasAuthorizationState($service, $account = null);
 
     /**
      * Retrieve the authorization state for a given service
      *
      * @param string $service
+     * @param string $account
      *
      * @return string
      */
-    public function retrieveAuthorizationState($service);
+    public function retrieveAuthorizationState($service, $account = null);
 
     /**
      * Clear the authorization state of a given service
      *
      * @param string $service
+     * @param string $account
      *
      * @return TokenStorageInterface
      */
-    public function clearAuthorizationState($service);
+    public function clearAuthorizationState($service, $account = null);
 
     /**
      * Delete *ALL* user authorization states. Use with care. Most of the time you will likely

--- a/src/OAuth/Common/Storage/TokenStorageInterface.php
+++ b/src/OAuth/Common/Storage/TokenStorageInterface.php
@@ -27,7 +27,7 @@ interface TokenStorageInterface
      *
      * @return TokenStorageInterface
      */
-    public function storeAccessToken($service, $account = null, TokenInterface $token);
+    public function storeAccessToken($service, TokenInterface $token, $account = null);
 
     /**
      * @param string $service
@@ -59,12 +59,12 @@ interface TokenStorageInterface
      * Store the authorization state related to a given service
      *
      * @param string $service
-     * @param string $account
      * @param string $state
+     * @param string $account
      *
      * @return TokenStorageInterface
      */
-    public function storeAuthorizationState($service, $account = null, $state);
+    public function storeAuthorizationState($service, $state, $account = null);
 
     /**
      * Check if an authorization state for a given service exists

--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -31,14 +31,24 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         ClientInterface $httpClient,
         TokenStorageInterface $storage,
         SignatureInterface $signature,
-        UriInterface $baseApiUri = null
+        UriInterface $baseApiUri = null,
+        $account = null
     ) {
-        parent::__construct($credentials, $httpClient, $storage);
+        parent::__construct($credentials, $httpClient, $storage, $account);
 
         $this->signature = $signature;
         $this->baseApiUri = $baseApiUri;
 
         $this->signature->setHashingAlgorithm($this->getSignatureMethod());
+
+        $this->init();
+    }
+
+    /**
+     * Constructor extended initialization
+     */
+    protected function init() {
+
     }
 
     /**
@@ -52,7 +62,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $responseBody = $this->httpClient->retrieveResponse($this->getRequestTokenEndpoint(), array(), $headers);
 
         $token = $this->parseRequestTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }
@@ -77,7 +87,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     public function requestAccessToken($token, $verifier, $tokenSecret = null)
     {
         if (is_null($tokenSecret)) {
-            $storedRequestToken = $this->storage->retrieveAccessToken($this->service());
+            $storedRequestToken = $this->storage->retrieveAccessToken($this->service(), $this->account());
             $tokenSecret = $storedRequestToken->getRequestTokenSecret();
         }
         $this->signature->setTokenSecret($tokenSecret);
@@ -90,7 +100,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             'Authorization' => $this->buildAuthorizationHeaderForAPIRequest(
                 'POST',
                 $this->getAccessTokenEndpoint(),
-                $this->storage->retrieveAccessToken($this->service()),
+                $this->storage->retrieveAccessToken($this->service(), $this->account()),
                 $bodyParams
             )
         );
@@ -100,7 +110,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), $bodyParams, $headers);
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }
@@ -131,7 +141,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $uri = $this->determineRequestUriFromPath($path, $this->baseApiUri);
 
         /** @var $token StdOAuth1Token */
-        $token = $this->storage->retrieveAccessToken($this->service());
+        $token = $this->storage->retrieveAccessToken($this->service(), $this->account());
         $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);
         $authorizationHeader = array(
             'Authorization' => $this->buildAuthorizationHeaderForAPIRequest($method, $uri, $token, $body)

--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -62,7 +62,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $responseBody = $this->httpClient->retrieveResponse($this->getRequestTokenEndpoint(), array(), $headers);
 
         $token = $this->parseRequestTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }
@@ -110,7 +110,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), $bodyParams, $headers);
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Service/BitBucket.php
+++ b/src/OAuth/OAuth1/Service/BitBucket.php
@@ -2,27 +2,18 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class BitBucket extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://bitbucket.org/api/1.0/');
         }
     }

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -15,20 +15,6 @@ class Etsy extends AbstractService
 {
 
     protected $scopes = array();
-//
-//    public function __construct(
-//        CredentialsInterface $credentials,
-//        ClientInterface $httpClient,
-//        TokenStorageInterface $storage,
-//        SignatureInterface $signature,
-//        UriInterface $baseApiUri = null
-//    ) {
-//        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-//
-//        if (null === $baseApiUri) {
-//            $this->baseApiUri = new Uri('https://openapi.etsy.com/v2/');
-//        }
-//    }
 
     /**
      * {@inheritdoc}

--- a/src/OAuth/OAuth1/Service/Etsy.php
+++ b/src/OAuth/OAuth1/Service/Etsy.php
@@ -15,17 +15,27 @@ class Etsy extends AbstractService
 {
 
     protected $scopes = array();
+//
+//    public function __construct(
+//        CredentialsInterface $credentials,
+//        ClientInterface $httpClient,
+//        TokenStorageInterface $storage,
+//        SignatureInterface $signature,
+//        UriInterface $baseApiUri = null
+//    ) {
+//        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
+//
+//        if (null === $baseApiUri) {
+//            $this->baseApiUri = new Uri('https://openapi.etsy.com/v2/');
+//        }
+//    }
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://openapi.etsy.com/v2/');
         }
     }

--- a/src/OAuth/OAuth1/Service/FitBit.php
+++ b/src/OAuth/OAuth1/Service/FitBit.php
@@ -2,27 +2,18 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class FitBit extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.fitbit.com/1/');
         }
     }

--- a/src/OAuth/OAuth1/Service/FiveHundredPx.php
+++ b/src/OAuth/OAuth1/Service/FiveHundredPx.php
@@ -9,14 +9,9 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 /**
  * 500px service.
@@ -27,22 +22,12 @@ use OAuth\Common\Http\Client\ClientInterface;
  */
 class FiveHundredPx extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $signature,
-            $baseApiUri
-        );
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.500px.com/v1/');
         }
     }

--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -2,28 +2,20 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class Flickr extends AbstractService
 {
     protected $format;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-        if ($baseApiUri === null) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.flickr.com/services/rest/');
         }
     }
@@ -88,7 +80,7 @@ class Flickr extends AbstractService
             }
         }
 
-        $token = $this->storage->retrieveAccessToken($this->service());
+        $token = $this->storage->retrieveAccessToken($this->service(), $this->account());
         $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);
         $authorizationHeader = array(
             'Authorization' => $this->buildAuthorizationHeaderForAPIRequest($method, $uri, $token, $body)

--- a/src/OAuth/OAuth1/Service/QuickBooks.php
+++ b/src/OAuth/OAuth1/Service/QuickBooks.php
@@ -5,33 +5,15 @@ namespace OAuth\OAuth1\Service;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\OAuth1\Signature\SignatureInterface;
 
 class QuickBooks extends AbstractService
 {
     /**
      * {@inheritdoc}
      */
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $signature,
-            $baseApiUri
-        );
-
-        if (null === $baseApiUri) {
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://quickbooks.api.intuit.com/');
         }
     }

--- a/src/OAuth/OAuth1/Service/Redmine.php
+++ b/src/OAuth/OAuth1/Service/Redmine.php
@@ -2,27 +2,18 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class Redmine extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             throw new \Exception('baseApiUri is a required argument.');
         }
     }

--- a/src/OAuth/OAuth1/Service/ScoopIt.php
+++ b/src/OAuth/OAuth1/Service/ScoopIt.php
@@ -2,27 +2,18 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class ScoopIt extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://www.scoop.it/api/1/');
         }
     }

--- a/src/OAuth/OAuth1/Service/Tumblr.php
+++ b/src/OAuth/OAuth1/Service/Tumblr.php
@@ -2,27 +2,18 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class Tumblr extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.tumblr.com/v2/');
         }
     }

--- a/src/OAuth/OAuth1/Service/Twitter.php
+++ b/src/OAuth/OAuth1/Service/Twitter.php
@@ -2,14 +2,9 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Exception\Exception;
 
 class Twitter extends AbstractService
@@ -19,16 +14,12 @@ class Twitter extends AbstractService
 
     protected $authorizationEndpoint   = self::ENDPOINT_AUTHENTICATE;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.twitter.com/1.1/');
         }
     }

--- a/src/OAuth/OAuth1/Service/Xing.php
+++ b/src/OAuth/OAuth1/Service/Xing.php
@@ -2,31 +2,22 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class Xing extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.xing.com/v1/');
         }
     }
-
+    
     /**
      * {@inheritdoc}
      */

--- a/src/OAuth/OAuth1/Service/Yahoo.php
+++ b/src/OAuth/OAuth1/Service/Yahoo.php
@@ -67,7 +67,7 @@ class Yahoo extends AbstractService
         $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), $bodyParams, $headers);
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth1/Service/Yahoo.php
+++ b/src/OAuth/OAuth1/Service/Yahoo.php
@@ -2,28 +2,19 @@
 
 namespace OAuth\OAuth1\Service;
 
-use OAuth\OAuth1\Signature\SignatureInterface;
 use OAuth\OAuth1\Token\StdOAuth1Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\OAuth1\Token\TokenInterface;
 
 class Yahoo extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        SignatureInterface $signature,
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $signature, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://social.yahooapis.com/v1/');
         }
     }
@@ -64,7 +55,7 @@ class Yahoo extends AbstractService
             'Authorization' => $this->buildAuthorizationHeaderForAPIRequest(
                 'POST',
                 $this->getAccessTokenEndpoint(),
-                $this->storage->retrieveAccessToken($this->service()),
+                $this->storage->retrieveAccessToken($this->service(), $this->account()),
                 $bodyParams
             )
         );
@@ -76,7 +67,7 @@ class Yahoo extends AbstractService
         $responseBody = $this->httpClient->retrieveResponse($this->getAccessTokenEndpoint(), $bodyParams, $headers);
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -304,7 +304,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      */
     protected function storeAuthorizationState($state)
     {
-        $this->storage->storeAuthorizationState($this->service(), $this->account(), $state);
+        $this->storage->storeAuthorizationState($this->service(), $state, $this->account());
     }
 
     /**

--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -136,7 +136,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         );
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }
@@ -235,7 +235,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -40,6 +40,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      * @param UriInterface|null     $baseApiUri
      * @param bool $stateParameterInAutUrl
      * @param string                $apiVersion
+     * @param string                $account
      *
      * @throws InvalidScopeException
      */
@@ -50,9 +51,10 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $scopes = array(),
         UriInterface $baseApiUri = null,
         $stateParameterInAutUrl = false,
-        $apiVersion = ""
+        $apiVersion = "",
+        $account = null
     ) {
-        parent::__construct($credentials, $httpClient, $storage);
+        parent::__construct($credentials, $httpClient, $storage, $account);
         $this->stateParameterInAuthUrl = $stateParameterInAutUrl;
 
         foreach ($scopes as $scope) {
@@ -66,8 +68,17 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         $this->baseApiUri = $baseApiUri;
 
         $this->apiVersion = $apiVersion;
+        
+        $this->init();
     }
 
+    /**
+     * Constructor extended initialization
+     */
+    protected function init() {
+        
+    }
+    
     /**
      * {@inheritdoc}
      */
@@ -125,7 +136,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         );
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }
@@ -148,7 +159,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         $uri = $this->determineRequestUriFromPath($path, $this->baseApiUri);
-        $token = $this->storage->retrieveAccessToken($this->service());
+        $token = $this->storage->retrieveAccessToken($this->service(), $this->account());
 
         if ($token->getEndOfLife() !== TokenInterface::EOL_NEVER_EXPIRES
             && $token->getEndOfLife() !== TokenInterface::EOL_UNKNOWN
@@ -224,7 +235,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }
@@ -283,7 +294,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      */
     protected function retrieveAuthorizationState()
     {
-        return $this->storage->retrieveAuthorizationState($this->service());
+        return $this->storage->retrieveAuthorizationState($this->service(), $this->account());
     }
 
     /**
@@ -293,7 +304,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      */
     protected function storeAuthorizationState($state)
     {
-        $this->storage->storeAuthorizationState($this->service(), $state);
+        $this->storage->storeAuthorizationState($this->service(), $this->account(), $state);
     }
 
     /**

--- a/src/OAuth/OAuth2/Service/Amazon.php
+++ b/src/OAuth/OAuth2/Service/Amazon.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Amazon service.
@@ -25,18 +21,14 @@ class Amazon extends AbstractService
     const SCOPE_PROFILE     = 'profile';
     const SCOPE_POSTAL_CODE = 'postal_code';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        if (null === $this->baseApiUri) {
             $this->baseApiUri = new Uri('https://api.amazon.com/');
-        }
+        } 
     }
 
     /**

--- a/src/OAuth/OAuth2/Service/BattleNet.php
+++ b/src/OAuth/OAuth2/Service/BattleNet.php
@@ -2,19 +2,17 @@
 
 namespace OAuth\OAuth2\Service;
 
-//-----------------------------------------------------------------------------
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
-//-----------------------------------------------------------------------------
+/**
+ * Class BattleNet
+ * @package OAuth\OAuth2\Service
+ */
 class BattleNet extends AbstractService { 
     
-    /** -----------------------------------------------------------------------
+    /** 
      * Defined scopes.
      *
      * @link https://dev.battle.net/docs
@@ -22,7 +20,7 @@ class BattleNet extends AbstractService {
     const SCOPE_WOW_PROFILE = "wow.profile";
     const SCOPE_SC2_PROFILE = "sc2.profile";
     
-    /** -----------------------------------------------------------------------
+    /** 
      * Defined API URIs.
      *
      * @link https://dev.battle.net/docs
@@ -34,21 +32,18 @@ class BattleNet extends AbstractService {
     const API_URI_CN  = 'https://api.battlenet.com.cn/';
     const API_URI_SEA = 'https://sea.api.battle.net/';
     
-    public function __construct( CredentialsInterface $credentials,
-                                 ClientInterface $httpClient,
-                                 TokenStorageInterface $storage,
-                                 $scopes = array(),
-                                 UriInterface $baseApiUri = null ) {
-                                 
-        parent::__construct( $credentials, $httpClient, $storage, 
-                             $scopes, $baseApiUri );
-        
-        if( $baseApiUri === null ) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri( self::API_URI_US );
         }
     }
+
     
-    /** -----------------------------------------------------------------------
+    /** 
      * Translates the current base API URI into an OAuth base URI. 
      *
      * @returns string Base URI of oauth services.
@@ -67,21 +62,21 @@ class BattleNet extends AbstractService {
         
     }
     
-    /** -----------------------------------------------------------------------
+    /** 
      * {@inheritdoc}
      */
     public function getAuthorizationEndpoint() {
         return new Uri( $this->GetOAuthBaseUri() . 'authorize' );
     }
     
-    /** -----------------------------------------------------------------------
+    /** 
      * {@inheritdoc}
      */
     public function getAccessTokenEndpoint() {
         return new Uri( $this->GetOAuthBaseUri() . 'token' );
     }
     
-    /** -----------------------------------------------------------------------
+    /** 
      * {@inheritdoc}
      */
     protected function getAuthorizationMethod()
@@ -89,7 +84,7 @@ class BattleNet extends AbstractService {
         return static::AUTHORIZATION_METHOD_QUERY_STRING;
     }
     
-    /** -----------------------------------------------------------------------
+    /** 
      * {@inheritdoc}
      */
     protected function parseAccessTokenResponse( $responseBody )

--- a/src/OAuth/OAuth2/Service/Bitly.php
+++ b/src/OAuth/OAuth2/Service/Bitly.php
@@ -97,7 +97,7 @@ class Bitly extends AbstractService
         parse_str($responseBody, $parsedResult);
 
         $token = $this->parseAccessTokenResponse(json_encode($parsedResult));
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Bitly.php
+++ b/src/OAuth/OAuth2/Service/Bitly.php
@@ -5,23 +5,16 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Bitly extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
 
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api-ssl.bitly.com/v3/');
         }
     }
@@ -104,7 +97,7 @@ class Bitly extends AbstractService
         parse_str($responseBody, $parsedResult);
 
         $token = $this->parseAccessTokenResponse(json_encode($parsedResult));
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Bitrix24.php
+++ b/src/OAuth/OAuth2/Service/Bitrix24.php
@@ -64,7 +64,7 @@ class Bitrix24 extends AbstractService
         );
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Bitrix24.php
+++ b/src/OAuth/OAuth2/Service/Bitrix24.php
@@ -64,7 +64,7 @@ class Bitrix24 extends AbstractService
         );
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Box.php
+++ b/src/OAuth/OAuth2/Service/Box.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Box service.
@@ -18,16 +14,14 @@ use OAuth\Common\Http\Uri\UriInterface;
  */
 class Box extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
+        
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.box.com/2.0/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Buffer.php
+++ b/src/OAuth/OAuth2/Service/Buffer.php
@@ -117,7 +117,7 @@ class Buffer extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Buffer.php
+++ b/src/OAuth/OAuth2/Service/Buffer.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 /**
  * Buffer API.
@@ -17,15 +13,12 @@ use OAuth\Common\Http\Client\ClientInterface;
  */
 class Buffer extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-        if ($baseApiUri === null) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.bufferapp.com/1/');
         }
     }
@@ -124,7 +117,7 @@ class Buffer extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Dailymotion.php
+++ b/src/OAuth/OAuth2/Service/Dailymotion.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Dailymotion service.
@@ -44,18 +40,11 @@ class Dailymotion extends AbstractService
           DISPLAY_MOBILE = 'mobile';
 
     /**
-    * {@inheritdoc}
-    */
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.dailymotion.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Deezer.php
+++ b/src/OAuth/OAuth2/Service/Deezer.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Deezer service.
@@ -38,23 +34,14 @@ class Deezer extends AbstractService
     const SCOPE_DELETE_LIBRARY    = 'delete_library';     // Delete library items
     const SCOPE_LISTENING_HISTORY = 'listening_history';  // Access the user's listening history
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
+        
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.deezer.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Delicious.php
+++ b/src/OAuth/OAuth2/Service/Delicious.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Delicious service.
@@ -26,23 +22,14 @@ use OAuth\Common\Http\Uri\UriInterface;
  */
 class Delicious extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.del.icio.us/v1/');
         }
     }
@@ -132,7 +119,7 @@ class Delicious extends AbstractService
         );
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Delicious.php
+++ b/src/OAuth/OAuth2/Service/Delicious.php
@@ -119,7 +119,7 @@ class Delicious extends AbstractService
         );
 
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/DeviantArt.php
+++ b/src/OAuth/OAuth2/Service/DeviantArt.php
@@ -2,14 +2,10 @@
 
 namespace OAuth\OAuth2\Service;
 
-use OAuth\Common\Exception\Exception;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
+
 
 class DeviantArt extends AbstractService
 {
@@ -33,16 +29,12 @@ class DeviantArt extends AbstractService
     const SCOPE_USER                       = 'user';
     const SCOPE_USERMANAGE                 = 'user.manage';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://www.deviantart.com/api/v1/oauth2/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Dropbox.php
+++ b/src/OAuth/OAuth2/Service/Dropbox.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Dropbox service.
@@ -18,16 +14,12 @@ use OAuth\Common\Http\Uri\UriInterface;
  */
 class Dropbox extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.dropbox.com/1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/EveOnline.php
+++ b/src/OAuth/OAuth2/Service/EveOnline.php
@@ -7,12 +7,9 @@
  */
 namespace OAuth\OAuth2\Service;
 
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
 use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Token\TokenInterface;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 
@@ -21,16 +18,12 @@ use OAuth\OAuth2\Token\StdOAuth2Token;
  */
 class EveOnline extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://login.eveonline.com');
         }
     }

--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -6,10 +6,6 @@ use OAuth\Common\Exception\Exception;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Facebook extends AbstractService
 {
@@ -122,17 +118,14 @@ class Facebook extends AbstractService
     const SCOPE_PAGES                         = 'manage_pages';
     const SCOPE_PUBLISH_PAGES                 = 'publish_pages';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null,
-        $apiVersion = ""
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true, $apiVersion);
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://graph.facebook.com'.$this->getApiVersionString().'/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Foursquare.php
+++ b/src/OAuth/OAuth2/Service/Foursquare.php
@@ -5,25 +5,17 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Foursquare extends AbstractService
 {
     private $apiVersionDate = '20130829';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.foursquare.com/v2/');
         }
     }

--- a/src/OAuth/OAuth2/Service/GitHub.php
+++ b/src/OAuth/OAuth2/Service/GitHub.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class GitHub extends AbstractService
 {
@@ -123,21 +119,17 @@ class GitHub extends AbstractService
      * Fully manage public keys.
      */
     const SCOPE_PUBLIC_KEY_ADMIN = 'admin:public_key';
-
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.github.com/');
         }
     }
-
+    
     /**
      * {@inheritdoc}
      */

--- a/src/OAuth/OAuth2/Service/Google.php
+++ b/src/OAuth/OAuth2/Service/Google.php
@@ -2,10 +2,6 @@
 
 namespace OAuth\OAuth2\Service;
 
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\OAuth2\Service\Exception\InvalidAccessTypeException;
@@ -130,16 +126,14 @@ class Google extends AbstractService
 
     protected $accessType = 'online';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://www.googleapis.com/oauth2/v1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Harvest.php
+++ b/src/OAuth/OAuth2/Service/Harvest.php
@@ -2,28 +2,19 @@
 
 namespace OAuth\OAuth2\Service;
 
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
 use OAuth\Common\Token\TokenInterface;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 
 class Harvest extends AbstractService
 {
-
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.harvestapp.com/');
         }
     }
@@ -132,7 +123,7 @@ class Harvest extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Harvest.php
+++ b/src/OAuth/OAuth2/Service/Harvest.php
@@ -123,7 +123,7 @@ class Harvest extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Heroku.php
+++ b/src/OAuth/OAuth2/Service/Heroku.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Heroku service.
@@ -30,18 +26,11 @@ class Heroku extends AbstractService
     const SCOPE_WRITE_PROTECTED = 'write-protected';
 
     /**
-    * {@inheritdoc}
-    */
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.heroku.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Hubic.php
+++ b/src/OAuth/OAuth2/Service/Hubic.php
@@ -40,6 +40,8 @@ class Hubic extends AbstractService
      */
     protected function init()
     {
+        $this->stateParameterInAuthUrl = true;
+
         if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.hubic.com/');
         }

--- a/src/OAuth/OAuth2/Service/Hubic.php
+++ b/src/OAuth/OAuth2/Service/Hubic.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Hubic service.
@@ -39,23 +35,12 @@ class Hubic extends AbstractService
     const SCOPE_LINKS_POST      = 'links.rw';
     const SCOPE_LINKS_ALL       = 'links.drw';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.hubic.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Instagram.php
+++ b/src/OAuth/OAuth2/Service/Instagram.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Instagram extends AbstractService
 {
@@ -22,17 +18,15 @@ class Instagram extends AbstractService
     const SCOPE_RELATIONSHIPS = 'relationships';
     const SCOPE_LIKES         = 'likes';
     const SCOPE_FOLLOWER_LIST = 'follower_list';
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.instagram.com/v1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/JawboneUP.php
+++ b/src/OAuth/OAuth2/Service/JawboneUP.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Jawbone UP service.
@@ -48,17 +44,12 @@ class JawboneUP extends AbstractService
     const SCOPE_GENERIC_EVENT_READ  = 'generic_event_read';
     const SCOPE_GENERIC_EVENT_WRITE = 'generic_event_write';
 
-
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://jawbone.com/nudge/api/v.1.1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Linkedin.php
+++ b/src/OAuth/OAuth2/Service/Linkedin.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Linkedin service.
@@ -33,16 +29,14 @@ class Linkedin extends AbstractService
     const SCOPE_W_MESSAGES          = 'w_messages';
     const SCOPE_W_SHARE             = 'w_share';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.linkedin.com/v1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Mailchimp.php
+++ b/src/OAuth/OAuth2/Service/Mailchimp.php
@@ -5,24 +5,16 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Mailchimp extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (is_null($this->baseApiUri) && $storage->hasAccessToken($this->service())) {
-            $this->setBaseApiUri($storage->retrieveAccessToken($this->service()));
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if (is_null($this->baseApiUri) && $this->getStorage()->hasAccessToken($this->service(), $this->account())) {
+            $this->setBaseApiUri($this->getStorage()->retrieveAccessToken($this->service(), $this->account()));
         }
     }
 
@@ -83,7 +75,7 @@ class Mailchimp extends AbstractService
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = array())
     {
         if (is_null($this->baseApiUri)) {
-            $this->setBaseApiUri($this->storage->retrieveAccessToken($this->service()));
+            $this->setBaseApiUri($this->storage->retrieveAccessToken($this->service(), $this->account()));
         }
 
         return parent::request($path, $method, $body, $extraHeaders);

--- a/src/OAuth/OAuth2/Service/Microsoft.php
+++ b/src/OAuth/OAuth2/Service/Microsoft.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Microsoft extends AbstractService
 {
@@ -50,16 +46,12 @@ class Microsoft extends AbstractService
      */
     const SCOPE_CONTACTS_EMAILS = 'wl.contacts_emails';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://apis.live.net/v5.0/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Mondo.php
+++ b/src/OAuth/OAuth2/Service/Mondo.php
@@ -5,23 +5,17 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Mondo extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.getmondo.co.uk');
         }
     }

--- a/src/OAuth/OAuth2/Service/Nest.php
+++ b/src/OAuth/OAuth2/Service/Nest.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Nest service.
@@ -26,24 +22,14 @@ use OAuth\Common\Http\Uri\UriInterface;
  */
 class Nest extends AbstractService
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://developer-api.nest.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Netatmo.php
+++ b/src/OAuth/OAuth2/Service/Netatmo.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Netatmo service.
@@ -36,24 +32,15 @@ class Netatmo extends AbstractService
     const SCOPE_THERMOSTAT_READ     = 'read_thermostat';
     // Used to configure the thermostat (syncschedule, setthermpoint)
     const SCOPE_THERMOSTAT_WRITE    = 'write_thermostat';
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true // use parameter state
-        );
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.netatmo.net/');
         }
     }

--- a/src/OAuth/OAuth2/Service/ParrotFlowerPower.php
+++ b/src/OAuth/OAuth2/Service/ParrotFlowerPower.php
@@ -121,7 +121,7 @@ class ParrotFlowerPower extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/ParrotFlowerPower.php
+++ b/src/OAuth/OAuth2/Service/ParrotFlowerPower.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\OAuth2\Service\Exception\MissingRefreshTokenException;
 use OAuth\Common\Token\TokenInterface;
 
@@ -28,24 +24,14 @@ use OAuth\Common\Token\TokenInterface;
  */
 class ParrotFlowerPower extends AbstractService
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://apiflowerpower.parrot.com/');
         }
     }
@@ -135,7 +121,7 @@ class ParrotFlowerPower extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Paypal.php
+++ b/src/OAuth/OAuth2/Service/Paypal.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * PayPal service.
@@ -31,16 +27,12 @@ class Paypal extends AbstractService
     const SCOPE_PHONE            = 'phone';
     const SCOPE_EXPRESSCHECKOUT  = 'https://uri.paypal.com/services/expresscheckout';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.paypal.com/v1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Pinterest.php
+++ b/src/OAuth/OAuth2/Service/Pinterest.php
@@ -12,10 +12,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Pinterest service.
@@ -35,23 +31,14 @@ class Pinterest extends AbstractService
     const SCOPE_READ_RELATIONSHIPS  = 'read_relationships';     // read a user’s follows (boards, users, interests)
     const SCOPE_WRITE_RELATIONSHIPS = 'write_relationships';    // follow boards, users and interests
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.pinterest.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Pocket.php
+++ b/src/OAuth/OAuth2/Service/Pocket.php
@@ -5,22 +5,17 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Uri\UriInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Client\ClientInterface;
 
 class Pocket extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-        if ($baseApiUri === null) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
+
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://getpocket.com/v3/');
         }
     }
@@ -98,7 +93,7 @@ class Pocket extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $token);
+        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Pocket.php
+++ b/src/OAuth/OAuth2/Service/Pocket.php
@@ -93,7 +93,7 @@ class Pocket extends AbstractService
             $this->getExtraOAuthHeaders()
         );
         $token = $this->parseAccessTokenResponse($responseBody);
-        $this->storage->storeAccessToken($this->service(), $this->account(), $token);
+        $this->storage->storeAccessToken($this->service(), $token, $this->account());
 
         return $token;
     }

--- a/src/OAuth/OAuth2/Service/Reddit.php
+++ b/src/OAuth/OAuth2/Service/Reddit.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Reddit extends AbstractService
 {
@@ -34,16 +30,14 @@ class Reddit extends AbstractService
     const SCOPE_MODLOG                       = 'modlog';
     const SCOPE_MODPOST                      = 'modpost';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://oauth.reddit.com');
         }
     }

--- a/src/OAuth/OAuth2/Service/RunKeeper.php
+++ b/src/OAuth/OAuth2/Service/RunKeeper.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * RunKeeper service.
@@ -17,20 +13,16 @@ use OAuth\Common\Http\Uri\UriInterface;
  */
 class RunKeeper extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.runkeeper.com/');
         }
     }
-
+    
     /**
      * {@inheritdoc}
      */

--- a/src/OAuth/OAuth2/Service/Salesforce.php
+++ b/src/OAuth/OAuth2/Service/Salesforce.php
@@ -2,14 +2,9 @@
 
 namespace OAuth\OAuth2\Service;
 
-use OAuth\OAuth2\Service\AbstractService;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Salesforce extends AbstractService
 {

--- a/src/OAuth/OAuth2/Service/SoundCloud.php
+++ b/src/OAuth/OAuth2/Service/SoundCloud.php
@@ -5,27 +5,19 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class SoundCloud extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.soundcloud.com/');
         }
     }
-
+    
     /**
      * {@inheritdoc}
      */

--- a/src/OAuth/OAuth2/Service/Spotify.php
+++ b/src/OAuth/OAuth2/Service/Spotify.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Spotify extends AbstractService
 {
@@ -29,16 +25,14 @@ class Spotify extends AbstractService
     const SCOPE_USER_READ_BIRTHDAY = 'user-read-birthdate';
     const SCOPE_USER_READ_FOLLOW = 'user-follow-read';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.spotify.com/v1/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Strava.php
+++ b/src/OAuth/OAuth2/Service/Strava.php
@@ -13,10 +13,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 use OAuth\OAuth2\Service\Exception\InvalidAccessTypeException;
 
 /**
@@ -41,27 +37,14 @@ class Strava extends AbstractService
 
     protected $approvalPrompt = 'auto';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        if (empty($scopes)) {
-            $scopes = array(self::SCOPE_PUBLIC);
-        }
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://www.strava.com/api/v3/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Ustream.php
+++ b/src/OAuth/OAuth2/Service/Ustream.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Ustream extends AbstractService
 {
@@ -19,17 +15,15 @@ class Ustream extends AbstractService
      */
     const SCOPE_OFFLINE     = 'offline';
     const SCOPE_BROADCASTER = 'broadcaster';
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri, true);
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.ustream.tv/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Vimeo.php
+++ b/src/OAuth/OAuth2/Service/Vimeo.php
@@ -13,10 +13,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 /**
  * Vimeo service.
@@ -54,24 +50,15 @@ class Vimeo extends AbstractService
     const SCOPE_INTERACT  = 'interact';
     // Upload a video
     const SCOPE_UPLOAD    = 'upload';
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        $this->stateParameterInAuthUrl = true;
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct(
-            $credentials,
-            $httpClient,
-            $storage,
-            $scopes,
-            $baseApiUri,
-            true
-        );
-
-        if (null === $baseApiUri) {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.vimeo.com/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Vkontakte.php
+++ b/src/OAuth/OAuth2/Service/Vkontakte.php
@@ -5,10 +5,6 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Vkontakte extends AbstractService
 {
@@ -39,16 +35,12 @@ class Vkontakte extends AbstractService
     const SCOPE_OFFLINE       = 'offline';
     const SCOPE_NOHTTPS       = 'nohttps';
 
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://api.vk.com/method/');
         }
     }

--- a/src/OAuth/OAuth2/Service/Yammer.php
+++ b/src/OAuth/OAuth2/Service/Yammer.php
@@ -5,23 +5,15 @@ namespace OAuth\OAuth2\Service;
 use OAuth\OAuth2\Token\StdOAuth2Token;
 use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\Uri;
-use OAuth\Common\Consumer\CredentialsInterface;
-use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Storage\TokenStorageInterface;
-use OAuth\Common\Http\Uri\UriInterface;
 
 class Yammer extends AbstractService
 {
-    public function __construct(
-        CredentialsInterface $credentials,
-        ClientInterface $httpClient,
-        TokenStorageInterface $storage,
-        $scopes = array(),
-        UriInterface $baseApiUri = null
-    ) {
-        parent::__construct($credentials, $httpClient, $storage, $scopes, $baseApiUri);
-
-        if (null === $baseApiUri) {
+    /**
+     * {@inheritdoc}
+     */
+    protected function init()
+    {
+        if( $this->baseApiUri === null ) {
             $this->baseApiUri = new Uri('https://www.yammer.com/api/v1/');
         }
     }

--- a/src/OAuth/ServiceFactory.php
+++ b/src/OAuth/ServiceFactory.php
@@ -98,6 +98,7 @@ class ServiceFactory
      * @param array|null            $scopes      If creating an oauth2 service, array of scopes
      * @param UriInterface|null     $baseApiUri
      * @param string                $apiVersion version of the api call
+     * @param null                  $account of service to create
      *
      * @return ServiceInterface
      */
@@ -107,7 +108,8 @@ class ServiceFactory
         TokenStorageInterface $storage,
         $scopes = array(),
         UriInterface $baseApiUri = null,
-        $apiVersion = ""
+        $apiVersion = "",
+        $account = null
     ) {
         if (!$this->httpClient) {
             // for backwards compatibility.
@@ -124,7 +126,8 @@ class ServiceFactory
                     $storage,
                     $scopes,
                     $baseApiUri,
-                    $apiVersion
+                    $apiVersion,
+                    $account
                 );
             }
         }
@@ -159,6 +162,8 @@ class ServiceFactory
      * @param TokenStorageInterface $storage
      * @param array|null            $scopes      Array of scopes for the service
      * @param UriInterface|null     $baseApiUri
+     * @param string                $apiVersion version of the api call
+     * @param null                  $account of service to create
      *
      * @return ServiceInterface
      *
@@ -170,7 +175,8 @@ class ServiceFactory
         TokenStorageInterface $storage,
         array $scopes,
         UriInterface $baseApiUri = null,
-        $apiVersion = ""
+        $apiVersion = "",
+        $account = null
     ) {
         return new $serviceName(
             $credentials,
@@ -178,7 +184,8 @@ class ServiceFactory
             $storage,
             $this->resolveScopes($serviceName, $scopes),
             $baseApiUri,
-            $apiVersion
+            $apiVersion,
+            $account
         );
     }
 
@@ -217,6 +224,7 @@ class ServiceFactory
      * @param TokenStorageInterface $storage
      * @param array                 $scopes
      * @param UriInterface          $baseApiUri
+     * @param null                  $account of service to create
      *
      * @return ServiceInterface
      *
@@ -227,7 +235,8 @@ class ServiceFactory
         CredentialsInterface $credentials,
         TokenStorageInterface $storage,
         $scopes,
-        UriInterface $baseApiUri = null
+        UriInterface $baseApiUri = null,
+        $account = null
     ) {
         if (!empty($scopes)) {
             throw new Exception(
@@ -235,6 +244,6 @@ class ServiceFactory
             );
         }
 
-        return new $serviceName($credentials, $this->httpClient, $storage, new Signature($credentials), $baseApiUri);
+        return new $serviceName($credentials, $this->httpClient, $storage, new Signature($credentials), $baseApiUri, $account);
     }
 }

--- a/tests/Unit/Common/Storage/MemoryTest.php
+++ b/tests/Unit/Common/Storage/MemoryTest.php
@@ -26,7 +26,7 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\\OAuth\\Common\\Storage\\Memory',
-            $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
+            $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
         );
     }
 
@@ -40,9 +40,9 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo', 'bar'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo'));
     }
 
     /**
@@ -68,9 +68,9 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('foo'));
     }
 
     /**
@@ -104,11 +104,11 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
-        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Memory', $storage->clearToken('foo', 'bar'));
-        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('foo'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Memory', $storage->clearToken('foo'));
+        $this->assertFalse($storage->hasAccessToken('foo'));
     }
 
     /**
@@ -120,13 +120,13 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
-        $storage->storeAccessToken('bar', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
-        $this->assertTrue($storage->hasAccessToken('bar', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('foo'));
+        $this->assertTrue($storage->hasAccessToken('bar'));
         $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Memory', $storage->clearAllTokens());
-        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
-        $this->assertFalse($storage->hasAccessToken('bar', 'bar'));
+        $this->assertFalse($storage->hasAccessToken('foo'));
+        $this->assertFalse($storage->hasAccessToken('bar'));
     }
 }

--- a/tests/Unit/Common/Storage/MemoryTest.php
+++ b/tests/Unit/Common/Storage/MemoryTest.php
@@ -26,7 +26,7 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\\OAuth\\Common\\Storage\\Memory',
-            $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
+            $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
         );
     }
 
@@ -40,9 +40,9 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo', 'bar'));
     }
 
     /**
@@ -68,9 +68,9 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo'));
+        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
     }
 
     /**
@@ -104,11 +104,11 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo'));
-        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Memory', $storage->clearToken('foo'));
-        $this->assertFalse($storage->hasAccessToken('foo'));
+        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Memory', $storage->clearToken('foo', 'bar'));
+        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
     }
 
     /**
@@ -120,13 +120,13 @@ class MemoryTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Memory();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
-        $storage->storeAccessToken('bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('bar', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo'));
-        $this->assertTrue($storage->hasAccessToken('bar'));
+        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('bar', 'bar'));
         $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Memory', $storage->clearAllTokens());
-        $this->assertFalse($storage->hasAccessToken('foo'));
-        $this->assertFalse($storage->hasAccessToken('bar'));
+        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
+        $this->assertFalse($storage->hasAccessToken('bar', 'bar'));
     }
 }

--- a/tests/Unit/Common/Storage/RedisTest.php
+++ b/tests/Unit/Common/Storage/RedisTest.php
@@ -54,15 +54,12 @@ class RedisTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
-        $account_1 = null;
-        $account_2 = null;
-
         $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
         $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service_1, $account_1, $token_1);
-        $this->storage->storeAccessToken($service_2, $account_2, $token_2);
+        $this->storage->storeAccessToken($service_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $token_2);
 
         // assert
         $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
@@ -92,11 +89,10 @@ class RedisTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
-        $account = null;
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $account, $token);
+        $this->storage->storeAccessToken($service, $token);
         $this->storage->clearToken($service);
 
         // assert

--- a/tests/Unit/Common/Storage/RedisTest.php
+++ b/tests/Unit/Common/Storage/RedisTest.php
@@ -54,12 +54,15 @@ class RedisTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
+        $account_1 = null;
+        $account_2 = null;
+
         $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
         $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service_1, $token_1);
-        $this->storage->storeAccessToken($service_2, $token_2);
+        $this->storage->storeAccessToken($service_1, $account_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $account_2, $token_2);
 
         // assert
         $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
@@ -89,10 +92,11 @@ class RedisTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
+        $account = null;
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $token);
+        $this->storage->storeAccessToken($service, $account, $token);
         $this->storage->clearToken($service);
 
         // assert

--- a/tests/Unit/Common/Storage/SessionTest.php
+++ b/tests/Unit/Common/Storage/SessionTest.php
@@ -74,7 +74,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\\OAuth\\Common\\Storage\\Session',
-            $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
+            $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
         );
     }
 
@@ -92,7 +92,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\\OAuth\\Common\\Storage\\Session',
-            $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
+            $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
         );
     }
 
@@ -108,9 +108,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo', 'bar'));
     }
 
     /**
@@ -140,9 +140,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo'));
+        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
     }
 
     /**
@@ -182,11 +182,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo'));
-        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Session', $storage->clearToken('foo'));
-        $this->assertFalse($storage->hasAccessToken('foo'));
+        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Session', $storage->clearToken('foo', 'bar'));
+        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
     }
 
     /**
@@ -200,14 +200,14 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
-        $storage->storeAccessToken('bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('bar', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo'));
-        $this->assertTrue($storage->hasAccessToken('bar'));
+        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('bar', 'bar'));
         $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Session', $storage->clearAllTokens());
-        $this->assertFalse($storage->hasAccessToken('foo'));
-        $this->assertFalse($storage->hasAccessToken('bar'));
+        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
+        $this->assertFalse($storage->hasAccessToken('bar', 'bar'));
     }
 
     /**
@@ -237,8 +237,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array('accessToken')));
 
         $storage = new Session();
-        $storage->storeAccessToken('foo', $mock);
-        $retrievedToken = $storage->retrieveAccessToken('foo');
+        $storage->storeAccessToken('foo', 'bar', $mock);
+        $retrievedToken = $storage->retrieveAccessToken('foo', 'bar');
 
         $this->assertInstanceOf('\\OAuth\\Common\\Token\\AbstractToken', $retrievedToken);
     }

--- a/tests/Unit/Common/Storage/SessionTest.php
+++ b/tests/Unit/Common/Storage/SessionTest.php
@@ -74,7 +74,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\\OAuth\\Common\\Storage\\Session',
-            $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
+            $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
         );
     }
 
@@ -92,7 +92,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\\OAuth\\Common\\Storage\\Session',
-            $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
+            $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'))
         );
     }
 
@@ -108,9 +108,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo', 'bar'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Token\\TokenInterface', $storage->retrieveAccessToken('foo'));
     }
 
     /**
@@ -140,9 +140,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('foo'));
     }
 
     /**
@@ -182,11 +182,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
-        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Session', $storage->clearToken('foo', 'bar'));
-        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('foo'));
+        $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Session', $storage->clearToken('foo'));
+        $this->assertFalse($storage->hasAccessToken('foo'));
     }
 
     /**
@@ -200,14 +200,14 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     {
         $storage = new Session();
 
-        $storage->storeAccessToken('foo', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
-        $storage->storeAccessToken('bar', 'bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('foo', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
+        $storage->storeAccessToken('bar', $this->getMock('\\OAuth\\Common\\Token\\TokenInterface'));
 
-        $this->assertTrue($storage->hasAccessToken('foo', 'bar'));
-        $this->assertTrue($storage->hasAccessToken('bar', 'bar'));
+        $this->assertTrue($storage->hasAccessToken('foo'));
+        $this->assertTrue($storage->hasAccessToken('bar'));
         $this->assertInstanceOf('\\OAuth\\Common\\Storage\\Session', $storage->clearAllTokens());
-        $this->assertFalse($storage->hasAccessToken('foo', 'bar'));
-        $this->assertFalse($storage->hasAccessToken('bar', 'bar'));
+        $this->assertFalse($storage->hasAccessToken('foo'));
+        $this->assertFalse($storage->hasAccessToken('bar'));
     }
 
     /**
@@ -237,8 +237,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(array('accessToken')));
 
         $storage = new Session();
-        $storage->storeAccessToken('foo', 'bar', $mock);
-        $retrievedToken = $storage->retrieveAccessToken('foo', 'bar');
+        $storage->storeAccessToken('foo', $mock);
+        $retrievedToken = $storage->retrieveAccessToken('foo');
 
         $this->assertInstanceOf('\\OAuth\\Common\\Token\\AbstractToken', $retrievedToken);
     }

--- a/tests/Unit/Common/Storage/StorageTest.php
+++ b/tests/Unit/Common/Storage/StorageTest.php
@@ -26,12 +26,15 @@ abstract class StorageTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
+        $account_1 = null;
+        $account_2 = null;
+
         $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
         $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service_1, $token_1);
-        $this->storage->storeAccessToken($service_2, $token_2);
+        $this->storage->storeAccessToken($service_1, $account_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $account_2, $token_2);
 
         // assert
         $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
@@ -61,10 +64,12 @@ abstract class StorageTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
+        $account = null;
+
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $token);
+        $this->storage->storeAccessToken($service, $account, $token);
         $this->storage->clearToken($service);
 
         // assert

--- a/tests/Unit/Common/Storage/StorageTest.php
+++ b/tests/Unit/Common/Storage/StorageTest.php
@@ -26,15 +26,12 @@ abstract class StorageTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
-        $account_1 = null;
-        $account_2 = null;
-
         $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
         $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service_1, $account_1, $token_1);
-        $this->storage->storeAccessToken($service_2, $account_2, $token_2);
+        $this->storage->storeAccessToken($service_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $token_2);
 
         // assert
         $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
@@ -64,12 +61,10 @@ abstract class StorageTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
-        $account = null;
-
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $account, $token);
+        $this->storage->storeAccessToken($service, $token);
         $this->storage->clearToken($service);
 
         // assert

--- a/tests/Unit/Common/Storage/SymfonySessionTest.php
+++ b/tests/Unit/Common/Storage/SymfonySessionTest.php
@@ -41,12 +41,10 @@ class SymfonySessionTest extends \PHPUnit_Framework_TestCase
     public function testStorageSurvivesConstructor()
     {
         $service = 'Facebook';
-        $account = null;
-
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $account, $token);
+        $this->storage->storeAccessToken($service, $token);
         $this->storage = null;
         $this->storage = new SymfonySession($this->session);
 
@@ -65,15 +63,12 @@ class SymfonySessionTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
-        $account_1 = null;
-        $account_2 = null;
-
         $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
         $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service_1, $account_1, $token_1);
-        $this->storage->storeAccessToken($service_2, $account_2, $token_2);
+        $this->storage->storeAccessToken($service_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $token_2);
 
         // assert
         $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
@@ -103,12 +98,10 @@ class SymfonySessionTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
-        $account = null;
-
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $account, $token);
+        $this->storage->storeAccessToken($service, $token);
         $this->storage->clearToken($service);
 
         // assert

--- a/tests/Unit/Common/Storage/SymfonySessionTest.php
+++ b/tests/Unit/Common/Storage/SymfonySessionTest.php
@@ -41,10 +41,12 @@ class SymfonySessionTest extends \PHPUnit_Framework_TestCase
     public function testStorageSurvivesConstructor()
     {
         $service = 'Facebook';
+        $account = null;
+
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $token);
+        $this->storage->storeAccessToken($service, $account, $token);
         $this->storage = null;
         $this->storage = new SymfonySession($this->session);
 
@@ -63,12 +65,15 @@ class SymfonySessionTest extends \PHPUnit_Framework_TestCase
         $service_1 = 'Facebook';
         $service_2 = 'Foursquare';
 
+        $account_1 = null;
+        $account_2 = null;
+
         $token_1 = new StdOAuth2Token('access_1', 'refresh_1', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
         $token_2 = new StdOAuth2Token('access_2', 'refresh_2', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service_1, $token_1);
-        $this->storage->storeAccessToken($service_2, $token_2);
+        $this->storage->storeAccessToken($service_1, $account_1, $token_1);
+        $this->storage->storeAccessToken($service_2, $account_2, $token_2);
 
         // assert
         $extraParams = $this->storage->retrieveAccessToken($service_1)->getExtraParams();
@@ -98,10 +103,12 @@ class SymfonySessionTest extends \PHPUnit_Framework_TestCase
     {
         // arrange
         $service = 'Facebook';
+        $account = null;
+
         $token = new StdOAuth2Token('access', 'refresh', StdOAuth2Token::EOL_NEVER_EXPIRES, array('extra' => 'param'));
 
         // act
-        $this->storage->storeAccessToken($service, $token);
+        $this->storage->storeAccessToken($service, $account, $token);
         $this->storage->clearToken($service);
 
         // assert


### PR DESCRIPTION
I have a case where I need multiple accounts for each service.
In the current implementation only TokenStorageInterface we could build a store with a variety of token and state prefixes, and have to build new Store instance for each Service.

I removed all the __constructors in Services and moved to initializing baseApiUrl to init() method, cutting the constructor AbstractService params was a bad idea.

It would be nice to fix appeared in your branch

P.S. Sorry for my English