### PR TITLE
script to create OAuth.phar

### DIFF
--- a/phar.php
+++ b/phar.php
@@ -1,0 +1,30 @@
+<?php
+$phar = new Phar('OAuth.phar', 0, 'OAuth.phar');
+$phar->buildFromDirectory ( 'src/OAuth' );
+$stub = <<<'EOS'
+<?php
+function oauth_autoload($class)
+{
+	if ( substr ( $class, 0, 6 ) == 'OAuth\\' )
+	{
+		$path = 'phar://OAuth.phar/' . str_replace('\\', '/', substr ( $class, 6 ) ) . '.php';
+		if ( is_file($path) )
+			include $path;
+	}
+}
+spl_autoload_register ( 'oauth_autoload', True );
+try
+{
+	phar::mapPhar ( 'OAuth.phar' );
+}
+catch ( PharException $e )
+{
+	echo $e->getMessage();
+	die ( 'Cannot initialize OAuth.phar' );
+}
+__HALT_COMPILER();
+?>
+EOS;
+$phar->setStub ( $stub );
+$phar->stopBuffering();
+?>


### PR DESCRIPTION
I'm still fairly new to php and the installation instructions for PHPoAuthLib seemed a little daunting to me. I really like phar files and took it on myself to learn a bit more about how phar files work by getting your library working that way.

The only change to the QuickBooks example that was necessary was that I replaced this:

require_once __DIR__ . '/bootstrap.php';

with this:

include 'OAuth.phar';
