### PR TITLE
Facebook client now attempts to decode responseBody first, then falls…

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -153,8 +153,11 @@ class Facebook extends AbstractService
      */
     protected function parseAccessTokenResponse($responseBody)
     {
-        // Facebook gives us a query string ... Oh wait. JSON is too simple, understand ?
-        parse_str($responseBody, $data);
+        $data = json_decode($responseBody, true);
+        if (! $data) {
+            // Facebook gives us a query string ... Oh wait. JSON is too simple, understand ?
+            parse_str($responseBody, $data);
+        }
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');


### PR DESCRIPTION
… back to parse_str if the decode is not successful.