### PR TITLE
Fix Facebook error struct display

### DIFF
--- a/src/OAuth/OAuth2/Service/Facebook.php
+++ b/src/OAuth/OAuth2/Service/Facebook.php
@@ -167,8 +167,8 @@ class Facebook extends AbstractService
 
         if (null === $data || !is_array($data)) {
             throw new TokenResponseException('Unable to parse response.');
-        } elseif (isset($data['error'])) {
-            throw new TokenResponseException('Error in retrieving token: "' . $data['error'] . '"');
+        } elseif (isset($data['error']) && isset($data['error']['message'])) {
+            throw new TokenResponseException('Error in retrieving token: "' . $data['error']['message'] . '"');
         }
 
         $token = new StdOAuth2Token();


### PR DESCRIPTION
Facebook returns the following JSON struct on an error:

```
{
    "error": {
        "message":"Error validating client secret.",
        "type":"OAuthException",
        "code":1,
        "fbtrace_id":"REMOVED"
    }
} 
```
So I fixed displaying the error message in the exception.