### PR TITLE
Travis - Remove PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ sudo: false
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
  
 matrix:


### PR DESCRIPTION
Hello!

PHP 5.3 is no more supported on Travis since Ubuntu Trusty
https://github.com/travis-ci/travis-ci/issues/8219

PHP 5.4 and 5.5 are no longer maintained.
http://php.net/supported-versions.php

What do you think to remove them too ?