### PR TITLE
Fix declaration of requestAccessToken method (php 7.2 support)

### DIFF
--- a/src/OAuth/OAuth2/Service/Buffer.php
+++ b/src/OAuth/OAuth2/Service/Buffer.php
@@ -108,7 +108,7 @@ class Buffer extends AbstractService
         return $data['code'];
     }
 
-    public function requestAccessToken($code)
+    public function requestAccessToken($code, $state = null)
     {
         $bodyParams = array(
             'client_id'     => $this->credentials->getConsumerId(),

--- a/src/OAuth/OAuth2/Service/Pocket.php
+++ b/src/OAuth/OAuth2/Service/Pocket.php
@@ -85,7 +85,7 @@ class Pocket extends AbstractService
         return $data['code'];
     }
     
-    public function requestAccessToken($code)
+    public function requestAccessToken($code, $state = null)
     {
         $bodyParams = array(
             'consumer_key'     => $this->credentials->getConsumerId(),

--- a/src/OAuth/OAuth2/Service/ServiceInterface.php
+++ b/src/OAuth/OAuth2/Service/ServiceInterface.php
@@ -29,10 +29,11 @@ interface ServiceInterface extends BaseServiceInterface
      * Retrieves and stores/returns the OAuth2 access token after a successful authorization.
      *
      * @param string $code The access code from the callback.
+     * @param string $state
      *
      * @return TokenInterface $token
      *
      * @throws TokenResponseException
      */
-    public function requestAccessToken($code);
+    public function requestAccessToken($code, $state = null);
 }


### PR DESCRIPTION
With PHP 7.2:

    Declaration of OAuth\OAuth2\Service\Pocket::requestAccessToken($code) must be compatible with OAuth\OAuth2\Service\AbstractService::requestAccessToken($code, $state = NULL) in /home/mickael/Netvibes/startpage/vendor/lusitanian/oauth/src/OAuth/OAuth2/Service/Pocket.php on line 125