### PR TITLE
Update Salesforce token length to "unknown"

### DIFF
--- a/src/OAuth/OAuth2/Service/Salesforce.php
+++ b/src/OAuth/OAuth2/Service/Salesforce.php
@@ -68,8 +68,7 @@ class Salesforce extends AbstractService
 
         $token = new StdOAuth2Token();
         $token->setAccessToken($data['access_token']);
-        // Salesforce tokens evidently never expire...
-        $token->setEndOfLife(StdOAuth2Token::EOL_NEVER_EXPIRES);
+        $token->setEndOfLife(StdOAuth2Token::EOL_UNKNOWN);
         unset($data['access_token']);
 
         if (isset($data['refresh_token'])) {


### PR DESCRIPTION
Salesforce token length should not be "never expire", but "unknown"

References:

- https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_understanding_refresh_token_oauth.htm
- https://salesforce.stackexchange.com/questions/73512/oauth-access-token-expiration