### PR TITLE
GitHub Fixes

### DIFF
--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -166,6 +166,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             $uri->addToQuery('auth', $token->getAccessToken());
         } elseif (static::AUTHORIZATION_METHOD_HEADER_BEARER === $this->getAuthorizationMethod()) {
             $extraHeaders = array_merge(['Authorization' => 'Bearer ' . $token->getAccessToken()], $extraHeaders);
+        } elseif (static::AUTHORIZATION_METHOD_HEADER_TOKEN === $this->getAuthorizationMethod()) {
+            $extraHeaders = array_merge(array('Authorization' => 'token ' . $token->getAccessToken()), $extraHeaders);
         }
 
         $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);

--- a/src/OAuth/OAuth2/Service/GitHub.php
+++ b/src/OAuth/OAuth2/Service/GitHub.php
@@ -203,7 +203,7 @@ class GitHub extends AbstractService
      */
     protected function getExtraApiHeaders()
     {
-        return ['Accept' => 'application/vnd.github.beta+json'];
+        return ['Accept' => 'application/vnd.github.v3+json'];
     }
 
     /**

--- a/src/OAuth/OAuth2/Service/GitHub.php
+++ b/src/OAuth/OAuth2/Service/GitHub.php
@@ -159,7 +159,7 @@ class GitHub extends AbstractService
      */
     protected function getAuthorizationMethod()
     {
-        return static::AUTHORIZATION_METHOD_QUERY_STRING;
+        return static::AUTHORIZATION_METHOD_HEADER_TOKEN;
     }
 
     /**

--- a/src/OAuth/OAuth2/Service/ServiceInterface.php
+++ b/src/OAuth/OAuth2/Service/ServiceInterface.php
@@ -19,6 +19,7 @@ interface ServiceInterface extends BaseServiceInterface
     const AUTHORIZATION_METHOD_QUERY_STRING_V2 = 3;
     const AUTHORIZATION_METHOD_QUERY_STRING_V3 = 4;
     const AUTHORIZATION_METHOD_QUERY_STRING_V4 = 5;
+    const AUTHORIZATION_METHOD_HEADER_TOKEN = 6;
 
     /**
      * Retrieves and stores/returns the OAuth2 access token after a successful authorization.

--- a/tests/Unit/OAuth2/Service/GitHubTest.php
+++ b/tests/Unit/OAuth2/Service/GitHubTest.php
@@ -90,7 +90,7 @@ class GitHubTest extends TestCase
     public function testGetAuthorizationMethod(): void
     {
         $client = $this->createMock('\\OAuth\\Common\\Http\\Client\\ClientInterface');
-        $client->expects(self::once())->method('retrieveResponse')->willReturnArgument(0);
+        $client->expects(self::once())->method('retrieveResponse')->willReturnArgument(2);
 
         $token = $this->createMock('\\OAuth\\OAuth2\\Token\\TokenInterface');
         $token->expects(self::once())->method('getEndOfLife')->willReturn(TokenInterface::EOL_NEVER_EXPIRES);
@@ -105,10 +105,9 @@ class GitHubTest extends TestCase
             $storage
         );
 
-        $uri = $service->request('https://pieterhordijk.com/my/awesome/path');
-        $absoluteUri = parse_url($uri->getAbsoluteUri());
-
-        self::assertSame('access_token=foo', $absoluteUri['query']);
+        $headers = $service->request('https://pieterhordijk.com/my/awesome/path');
+        self::assertArrayHasKey('Authorization', $headers);
+        self::assertTrue(in_array('token foo', $headers, true));
     }
 
     /**

--- a/tests/Unit/OAuth2/Service/GitHubTest.php
+++ b/tests/Unit/OAuth2/Service/GitHubTest.php
@@ -216,6 +216,6 @@ class GitHubTest extends TestCase
         $headers = $service->request('https://pieterhordijk.com/my/awesome/path');
 
         self::assertArrayHasKey('Accept', $headers);
-        self::assertSame('application/vnd.github.beta+json', $headers['Accept']);
+        self::assertSame('application/vnd.github.v3+json', $headers['Accept']);
     }
 }


### PR DESCRIPTION
This fixes the Github service to make use of the correct stable API and send token as headers instead using the deprecated method of request parameters. See commits for details. Tests have been adjusted.