### PR TITLE
Carrying over refresh token

### DIFF
--- a/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/src/OAuth/OAuth2/Service/AbstractService.php
@@ -211,6 +211,9 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             $parameters,
             $this->getExtraOAuthHeaders()
         );
+
+        $responseBody = $this->carryRefreshToken($responseBody, $refreshToken);
+
         $token = $this->parseAccessTokenResponse($responseBody);
         $this->storage->storeAccessToken($this->service(), $token);
 
@@ -239,6 +242,26 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     public function needsStateParameterInAuthUrl()
     {
         return $this->stateParameterInAuthUrl;
+    }
+
+    /**
+     * Carry the refresh_token for next time getting refreshed
+     *
+     * @param $responseBody
+     *
+     * @param $refreshToken
+     *
+     * @return string
+     */
+    protected function carryRefreshToken($responseBody, $refreshToken)
+    {
+        $responseJson = json_decode($responseBody, true);
+        if (empty($responseJson['refresh_token'])) {
+            $responseJson['refresh_token'] = $refreshToken;
+            return json_encode($responseJson);
+        } else {
+            return $responseBody;
+        }
     }
 
     /**


### PR DESCRIPTION
This builds upon the work done in PR 381. That ticket is on hold because it was perceived to be a Google specific issue, but I think the issue is broader then that. I noticed the same issue on SalesForce and Issue #26 reports the same issue for Facebook. I took a look at the oAuth specification and I think I see where the disconnect is. Take a look at the diagram in this section on authorization flow: [https://tools.ietf.org/html/rfc6749#section-1.5](https://tools.ietf.org/html/rfc6749#section-1.5) 

G and H in the diagram document the refresh-token flow and according to H the server may _optionally_ return a new refresh token as part of that request. For environments that don't expire the refresh token, it is never returned. I think since the RFC for it says it's optional we should account for it at the abstract service layer. 

This takes the approach in PR 381 but with an added check to be sure the refresh token is absent before it carries it over, to ensure it doesn't break flows that do decide to return a new refresh token. 