### PR TITLE
Fix array_walk usage on PHP 8

### DIFF
--- a/src/OAuth/Common/Http/Client/AbstractClient.php
+++ b/src/OAuth/Common/Http/Client/AbstractClient.php
@@ -64,8 +64,7 @@ abstract class AbstractClient implements ClientInterface
         // Normalize headers
         array_walk(
             $headers,
-            function (&$val, &$key): void {
-                $key = ucfirst(strtolower($key));
+            function (&$val, $key): void {
                 $val = ucfirst(strtolower($key)) . ': ' . $val;
             }
         );


### PR DESCRIPTION
The old behavior of modifying keys was never supported, and is now an error in PHP 8, breaking most functionality of this library.

See the top comment in the [PHP user notes](https://www.php.net/array-walk#usernotes) 16 years ago explaining this behavior.