### PR TITLE
Support to upload Flickr Images

### DIFF
--- a/src/OAuth/OAuth1/Service/Flickr.php
+++ b/src/OAuth/OAuth1/Service/Flickr.php
@@ -28,6 +28,11 @@ class Flickr extends AbstractService
         }
     }
 
+    public function getUploadServiceEndpoint()
+    {
+        return new Uri('https://www.flickr.com/services/oauth/request_token');
+    }
+
     public function getRequestTokenEndpoint()
     {
         return new Uri('https://www.flickr.com/services/oauth/request_token');
@@ -79,7 +84,9 @@ class Flickr extends AbstractService
     public function request($path, $method = 'GET', $body = null, array $extraHeaders = [])
     {
         $uri = $this->determineRequestUriFromPath('/', $this->baseApiUri);
-        $uri->addToQuery('method', $path);
+        if ($this->baseApiUri->getAbsoluteUri() !== $this->getUploadServiceEndpoint()->getAbsoluteUri()) {
+            $uri->addToQuery('method', $path);
+        }
 
         if (!empty($this->format)) {
             $uri->addToQuery('format', $this->format);


### PR DESCRIPTION
I'm adding a feature to upload Flickr images directly from this lib.

Usage:

```PHP
$flickrService = $serviceFactory->createService('Flickr', $credentials, $storage, [],
    new OAuth\Common\Http\Uri\Uri('https://up.flickr.com/services/upload/')
);

$multipart = '--------------------------'  .  microtime(true);
$fileName = __DIR__  .  '/img.png';
$fileBin = file_get_contents($fileName);

$content =  "--" . $multipart."\r\n".
"Content-Disposition: form-data; name=\"photo\"; filename=\"".basename($fileName)."\"\r\n".
"Content-Type: application/png\r\n\r\n".
$fileBin."\r\n";

// signal end of request (note the trailing "--")
$content .= "--" . $multipart . "--\r\n";

$req = $flickrService->request(
  '/',
  'POST',
  $content,
  ['Content-Type' => 'multipart/form-data; boundary=' . $multipart]
);

$x = simplexml_load_string($req);
$photoId = (string)$x->photoid;
var_dump('<pre>', $x, (string)$x->photoid);
```