### PR TITLE
Update Signature.php

### DIFF
--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -114,6 +114,8 @@ class Signature implements SignatureInterface
         switch (strtoupper($this->algorithm)) {
             case 'HMAC-SHA1':
                 return hash_hmac('sha1', $data, $this->getSigningKey(), true);
+            case 'HMAC-SHA256':
+                return hash_hmac('sha256', $data, $this->getSigningKey(), true);
             default:
                 throw new UnsupportedHashAlgorithmException(
                     'Unsupported hashing algorithm (' . $this->algorithm . ') used.'


### PR DESCRIPTION
Support for HMAC-SHA256
Fix for: #586 Magento 2
 
To use it, you need to overwide the following function:

class OauthClient extends AbstractService
{
    protected function getSignatureMethod()
    {
        return 'HMAC-SHA256';
    }
}