### PR TITLE
Bugfix sleep breaks oauth1 signature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lusitanian/oauth",
+    "name": "jeroenvermeulen/oauth",
     "description": "PHP 7.2 oAuth 1/2 Library",
     "keywords": ["oauth", "authentication", "authorization", "security"],
     "license": "MIT",
@@ -15,7 +15,11 @@
         {
             "name": "Elliot Chance",
             "email": "elliotchance@gmail.com"
-        }
+        },
+        {
+            "name": "Jeroen Vermeulen",
+            "email": "info@jeroenvermeulen.eu"
+        }        
     ],
     "scripts" : {
         "tests" : [

--- a/src/OAuth/Common/Token/AbstractToken.php
+++ b/src/OAuth/Common/Token/AbstractToken.php
@@ -122,9 +122,4 @@ abstract class AbstractToken implements TokenInterface
         && $this->getEndOfLife() !== TokenInterface::EOL_UNKNOWN
         && time() > $this->getEndOfLife();
     }
-
-    public function __sleep()
-    {
-        return ['accessToken'];
-    }
 }

--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -23,6 +23,9 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
     /** @var null|UriInterface */
     protected $baseApiUri;
 
+    /** @var string */
+    protected $signatureMethod = 'HMAC-SHA1';
+
     /**
      * {@inheritdoc}
      */
@@ -274,17 +277,18 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
      */
     protected function getSignatureMethod()
     {
-        return 'HMAC-SHA1';
+        return $this->signatureMethod;
     }
 
     /**
-     * This returns the version used in the authorization header of the requests.
+     * Set the signature method.
+     * Currently supported: 'HMAC-SHA1' and 'HMAC-SHA256'
      *
-     * @return string
+     * @param string $method
      */
-    protected function getVersion()
+    protected function setSignatureMethod($method)
     {
-        return '1.0';
+        $this->signatureMethod = (string) $method;
     }
 
     /**

--- a/src/OAuth/OAuth1/Service/AbstractService.php
+++ b/src/OAuth/OAuth1/Service/AbstractService.php
@@ -246,7 +246,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             'oauth_nonce' => $this->generateNonce(),
             'oauth_signature_method' => $this->getSignatureMethod(),
             'oauth_timestamp' => $dateTime->format('U'),
-            'oauth_version' => $this->getVersion(),
+            'oauth_version' => '1.0',
         ];
 
         return $headerParameters;

--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -114,6 +114,8 @@ class Signature implements SignatureInterface
         switch (strtoupper($this->algorithm)) {
             case 'HMAC-SHA1':
                 return hash_hmac('sha1', $data, $this->getSigningKey(), true);
+            case 'HMAC-SHA256':
+                return hash_hmac('sha256', $data, $this->getSigningKey(), true);
             default:
                 throw new UnsupportedHashAlgorithmException(
                     'Unsupported hashing algorithm (' . $this->algorithm . ') used.'


### PR DESCRIPTION
After quite some debugging I found out the `__sleep` function in `OAuth\Common\Token\AbstractToken` breaks the signature in Oauth1.