### PR TITLE
Fix sign URL with array param

### DIFF
--- a/src/OAuth/OAuth1/Signature/Signature.php
+++ b/src/OAuth/OAuth1/Signature/Signature.php
@@ -53,7 +53,7 @@ class Signature implements SignatureInterface
     {
         parse_str($uri->getQuery(), $queryStringData);
 
-        $signatureData = $this->urlEncodeArray(array_merge($queryStringData, $params));
+        $signatureData = array_merge($queryStringData, $params);
 
         // determine base uri
         $baseUri = $uri->getScheme() . '://' . $uri->getRawAuthority();
@@ -66,11 +66,10 @@ class Signature implements SignatureInterface
 
         $baseString = strtoupper($method) . '&';
         $baseString .= rawurlencode($baseUri) . '&';
-        $baseString .= rawurlencode(http_build_query($signatureData, '', '&'));
+        $baseString .= http_build_query($signatureData, '', '&', PHP_QUERY_RFC3986);
 
         return base64_encode($this->hash($baseString));
     }
-
 
     /**
      * @return string
@@ -116,26 +115,5 @@ class Signature implements SignatureInterface
                     'Unsupported hashing algorithm (' . $this->algorithm . ') used.'
                 );
         }
-    }
-
-    /**
-     * URL encodes both keys and values in an array, recusively.
-     * Sorts the array by key after encoding.
-     *
-     * @param array $data
-     * @return array
-     */
-    protected function urlEncodeArray(array $data)
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            if (is_array($value)) {
-                $result[rawurlencode($key)] = $this->rawUrlEncodeArray($value);
-            } else {
-                $result[rawurlencode($key)] = rawurlencode($value);
-            }
-        }
-        ksort($result);
-        return $result;
     }
 }

--- a/tests/Unit/OAuth1/Signature/SignatureTest.php
+++ b/tests/Unit/OAuth1/Signature/SignatureTest.php
@@ -44,6 +44,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */
@@ -81,6 +82,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */
@@ -118,6 +120,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */
@@ -155,6 +158,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */
@@ -195,6 +199,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */
@@ -235,6 +240,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */
@@ -274,6 +280,7 @@ class SignatureTest extends TestCase
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
+     * @covers \OAuth\OAuth1\Signature\Signature::ksortRecursive
      * @covers \OAuth\OAuth1\Signature\Signature::setHashingAlgorithm
      * @covers \OAuth\OAuth1\Signature\Signature::setTokenSecret
      */

--- a/tests/Unit/OAuth1/Signature/SignatureTest.php
+++ b/tests/Unit/OAuth1/Signature/SignatureTest.php
@@ -41,7 +41,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
@@ -79,7 +78,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
@@ -117,7 +115,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
@@ -155,7 +152,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
@@ -196,7 +192,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
@@ -237,7 +232,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash
@@ -277,7 +271,6 @@ class SignatureTest extends TestCase
 
     /**
      * @covers \OAuth\OAuth1\Signature\Signature::__construct
-     * @covers \OAuth\OAuth1\Signature\Signature::buildSignatureDataString
      * @covers \OAuth\OAuth1\Signature\Signature::getSignature
      * @covers \OAuth\OAuth1\Signature\Signature::getSigningKey
      * @covers \OAuth\OAuth1\Signature\Signature::hash


### PR DESCRIPTION
Fixes #596

I let `http_build_query` do the work of recursively URL encoding the query parameters, we no longer need the method `buildSignatureDataString`. Added method `ksortRecursive` to sort array URL parameters recursively.